### PR TITLE
Add support for multiple endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,20 +172,39 @@ but in certain scenarios it can be useful to determine problems with individual 
 Example:
 
 ```
-Requests:
- * Fastest: 2.9965ms Slowest: 62.9993ms 50%: 21.0006ms 90%: 31.0021ms 99%: 41.0016ms n: 16720
-
-Requests by host:
- * http://127.0.0.1:9001 - Fastest: 2.9965ms Slowest: 55.0015ms 50%: 18.0002ms 90%: 28.001ms n: 2395
- * http://127.0.0.1:9002 - Fastest: 4.999ms Slowest: 60.9925ms 50%: 20.9993ms 90%: 31.001ms n: 2395
- * http://127.0.0.1:9003 - Fastest: 6.9988ms Slowest: 56.0005ms 50%: 20.9978ms 90%: 31.001ms n: 2395
- * http://127.0.0.1:9004 - Fastest: 5.0002ms Slowest: 62.9993ms 50%: 22.0009ms 90%: 33.001ms n: 2395
- * http://127.0.0.1:9005 - Fastest: 6.9934ms Slowest: 54.002ms 50%: 21.0008ms 90%: 30.9998ms n: 2396
- * http://127.0.0.1:9006 - Fastest: 6.0019ms Slowest: 54.9972ms 50%: 22.9985ms 90%: 33.0007ms n: 2396
- * http://127.0.0.1:9007 - Fastest: 7.9968ms Slowest: 55.0899ms 50%: 21.998ms 90%: 30.9998ms n: 2396
+Operation: GET. Concurrency: 12. Hosts: 7.                                                       
+                                                                                                 
+Requests - 16720:                                                                                
+ * Fastest: 2.9965ms Slowest: 62.9993ms 50%: 21.0006ms 90%: 31.0021ms 99%: 41.0016ms             
+ * First Byte: Average: 20.575134ms, Median: 20.0007ms, Best: 1.9985ms, Worst: 62.9993ms         
+                                                                                                 
+Requests by host:                                                                                
+ * http://127.0.0.1:9001 - 2395 requests:                                                        
+        - Fastest: 2.9965ms Slowest: 55.0015ms 50%: 18.0002ms 90%: 28.001ms                      
+        - First Byte: Average: 17.139147ms, Median: 16.9998ms, Best: 1.9985ms, Worst: 53.0026ms  
+ * http://127.0.0.1:9002 - 2395 requests:                                                        
+        - Fastest: 4.999ms Slowest: 60.9925ms 50%: 20.9993ms 90%: 31.001ms                       
+        - First Byte: Average: 20.174683ms, Median: 19.9996ms, Best: 3.999ms, Worst: 59.9912ms   
+ * http://127.0.0.1:9003 - 2395 requests:                                                        
+        - Fastest: 6.9988ms Slowest: 56.0005ms 50%: 20.9978ms 90%: 31.001ms                      
+        - First Byte: Average: 20.272876ms, Median: 19.9983ms, Best: 5.0012ms, Worst: 55.0012ms  
+ * http://127.0.0.1:9004 - 2395 requests:                                                        
+        - Fastest: 5.0002ms Slowest: 62.9993ms 50%: 22.0009ms 90%: 33.001ms                      
+        - First Byte: Average: 22.039164ms, Median: 21.0015ms, Best: 4.0003ms, Worst: 62.9993ms  
+ * http://127.0.0.1:9005 - 2396 requests:                                                        
+        - Fastest: 6.9934ms Slowest: 54.002ms 50%: 21.0008ms 90%: 30.9998ms                      
+        - First Byte: Average: 20.871833ms, Median: 20.0006ms, Best: 4.9998ms, Worst: 52.0019ms  
+ * http://127.0.0.1:9006 - 2396 requests:                                                        
+        - Fastest: 6.0019ms Slowest: 54.9972ms 50%: 22.9985ms 90%: 33.0007ms                     
+        - First Byte: Average: 22.430863ms, Median: 21.9986ms, Best: 5.0008ms, Worst: 53.9981ms  
+ * http://127.0.0.1:9007 - 2396 requests:                                                        
+        - Fastest: 7.9968ms Slowest: 55.0899ms 50%: 21.998ms 90%: 30.9998ms                      
+        - First Byte: Average: 21.049681ms, Median: 20.9989ms, Best: 6.9958ms, Worst: 54.0884ms  
 ```
 
 The fastest and slowest request times are shown, as well as selected percentiles and the total amount is requests considered.
+
+Note that different metrics are used to select the number of requests per host and for the combined, so there will likely be differences.
 
 ### CSV output
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,30 @@ Aggregated, split into 59 x 1s time segments:
 * 50% Median: 2419.56 MB/s, 241.96 obj/s, 240.00 ops ended/s (1s)
 * Slowest: 1137.36 MB/s, 113.74 obj/s, 112.00 ops ended/s (1s)
 ```
+### Per request statistics
+
+By adding the `-requests` parameter it is possible to display per request statistics.
+
+This is not enabled by default, since it is assumed the benchmarks are throughput limited, 
+but in certain scenarios it can be useful to determine problems with individual hosts for instance.
+
+Example:
+
+```
+Requests:
+ * Fastest: 2.9965ms Slowest: 62.9993ms 50%: 21.0006ms 90%: 31.0021ms 99%: 41.0016ms n: 16720
+
+Requests by host:
+ * http://127.0.0.1:9001 - Fastest: 2.9965ms Slowest: 55.0015ms 50%: 18.0002ms 90%: 28.001ms n: 2395
+ * http://127.0.0.1:9002 - Fastest: 4.999ms Slowest: 60.9925ms 50%: 20.9993ms 90%: 31.001ms n: 2395
+ * http://127.0.0.1:9003 - Fastest: 6.9988ms Slowest: 56.0005ms 50%: 20.9978ms 90%: 31.001ms n: 2395
+ * http://127.0.0.1:9004 - Fastest: 5.0002ms Slowest: 62.9993ms 50%: 22.0009ms 90%: 33.001ms n: 2395
+ * http://127.0.0.1:9005 - Fastest: 6.9934ms Slowest: 54.002ms 50%: 21.0008ms 90%: 30.9998ms n: 2396
+ * http://127.0.0.1:9006 - Fastest: 6.0019ms Slowest: 54.9972ms 50%: 22.9985ms 90%: 33.0007ms n: 2396
+ * http://127.0.0.1:9007 - Fastest: 7.9968ms Slowest: 55.0899ms 50%: 21.998ms 90%: 30.9998ms n: 2396
+```
+
+The fastest and slowest request times are shown, as well as selected percentiles and the total amount is requests considered.
 
 ### CSV output
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ The S3 server to use can be specified on the commandline using `-host`, `-access
 
 It is also possible to set the same parameters using the `WARP_HOST`, `WARP_ACCESS_KEY`, `WARP_SECRET_KEY` and `WARP_TLS` environment variables.
 
-Multiple hosts can be specified as comma-separated values, for instance `10.0.0.1:9000,10.0.0.2:9000,10.0.0.3:9000` 
-will do a round-robin between the specified servers.
+Multiple hosts can be specified as comma-separated values, for instance `10.0.0.1:9000,10.0.0.2:9000` 
+will do a round-robin between the specified servers. 
+
+Alternatively numerical ranges can be specified using `10.0.0.{1...10}:9000` which will add `10.0.0.1` through `10.0.0.10`.
+This syntax can be used for any part of the host name and port.  
  
 The credentials must be able to create, delete and list buckets and upload files and perform the operation requested.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The S3 server to use can be specified on the commandline using `-host`, `-access
 
 It is also possible to set the same parameters using the `WARP_HOST`, `WARP_ACCESS_KEY`, `WARP_SECRET_KEY` and `WARP_TLS` environment variables.
 
+Multiple hosts can be specified as comma-separated values, for instance `10.0.0.1:9000,10.0.0.2:9000,10.0.0.3:9000` 
+will do a round-robin between the specified servers.
+ 
 The credentials must be able to create, delete and list buckets and upload files and perform the operation requested.
 
 By default operations are performed on a bucket called `warp-benchmark-bucket`.

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -146,9 +146,9 @@ func printAnalysis(ctx *cli.Context, ops bench.Operations) {
 		opo := ops.FirstObjPerOp()
 		console.SetColor("Print", color.New(color.FgHiWhite))
 		if opo > 1 {
-			console.Println("Operation:", typ, opo, "objects per operation. Concurrency:", ops.Threads())
+			console.Printf("Operation: %v. Objects per operation: %d. Concurrency: %d. Hosts: %d.\n", typ, opo, ops.Threads(), ops.Hosts())
 		} else {
-			console.Println("Operation:", typ, "- Concurrency:", ops.Threads())
+			console.Printf("Operation: %v. Concurrency: %d. Hosts: %d.\n", typ, ops.Threads(), ops.Hosts())
 		}
 		if errs := ops.Errors(); len(errs) > 0 {
 			console.SetColor("Print", color.New(color.FgHiRed))

--- a/cli/client.go
+++ b/cli/client.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"errors"
+	"strings"
+	"sync"
+
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/probe"
 	"github.com/minio/minio-go/v6"
@@ -8,15 +12,45 @@ import (
 	"github.com/minio/warp/pkg"
 )
 
-func newClient(ctx *cli.Context) *minio.Client {
-	cl, err := minio.New(ctx.String("host"), ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
-	fatalIf(probe.NewError(err), "Unable to create MinIO client")
-	cl.SetAppInfo(appName, pkg.Version)
-	return cl
+func newClient(ctx *cli.Context) func() *minio.Client {
+	hosts := strings.Split(ctx.String("host"), ",")
+	switch len(hosts) {
+	case 0:
+		fatalIf(probe.NewError(errors.New("no host defined")), "Unable to create MinIO client")
+	case 1:
+		cl, err := minio.New(hosts[0], ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
+		fatalIf(probe.NewError(err), "Unable to create MinIO client")
+		cl.SetAppInfo(appName, pkg.Version)
+		return func() *minio.Client {
+			return cl
+		}
+	}
+	// Do round-robin.
+	var current int
+	var mu sync.Mutex
+	clients := make([]*minio.Client, len(hosts))
+	for i := range hosts {
+		cl, err := minio.New(hosts[i], ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
+		fatalIf(probe.NewError(err), "Unable to create MinIO client")
+		cl.SetAppInfo(appName, pkg.Version)
+		clients[i] = cl
+	}
+	return func() *minio.Client {
+		mu.Lock()
+		now := current % len(clients)
+		current++
+		mu.Unlock()
+		return clients[now]
+
+	}
 }
 
 func newAdminClient(ctx *cli.Context) *madmin.AdminClient {
-	cl, err := madmin.New(ctx.String("host"), ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
+	hosts := strings.Split(ctx.String("host"), ",")
+	if len(hosts) == 0 {
+		fatalIf(probe.NewError(errors.New("no host defined")), "Unable to create MinIO admin client")
+	}
+	cl, err := madmin.New(hosts[0], ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
 	fatalIf(probe.NewError(err), "Unable to create MinIO admin client")
 	cl.SetAppInfo(appName, pkg.Version)
 	return cl

--- a/cli/cmp.go
+++ b/cli/cmp.go
@@ -93,7 +93,7 @@ func printCompare(ctx *cli.Context, before, after bench.Operations) {
 	}
 	_ = wrSegs
 	timeDur := func(ops bench.Operations) time.Duration {
-		start, end := ops.ActiveTimeRange()
+		start, end := ops.ActiveTimeRange(true)
 		return end.Sub(start).Round(time.Second)
 	}
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -115,7 +115,7 @@ func setGlobals(quiet, debug, json, noColor bool) {
 var ioFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:   "host",
-		Usage:  "host",
+		Usage:  "host. Multiple hosts can be specified as a comma separated list.",
 		EnvVar: appNameUC + "_HOST",
 		Value:  "127.0.0.1:9000",
 	},

--- a/cli/merge.go
+++ b/cli/merge.go
@@ -110,7 +110,7 @@ func mainMerge(ctx *cli.Context) error {
 		}()
 	}
 	for typ, ops := range allOps.ByOp() {
-		start, end := ops.ActiveTimeRange()
+		start, end := ops.ActiveTimeRange(true)
 		if !start.Before(end) {
 			console.Errorf("Type %v contains no overlapping items", typ)
 		}

--- a/pkg/bench/analyze.go
+++ b/pkg/bench/analyze.go
@@ -62,13 +62,13 @@ type Segments []Segment
 // Total will return the total of active operations.
 // See ActiveTimeRange how this is determined.
 // Specify whether one operation for all threads should be skipped or just a single.
-func (o Operations) Total(allThreads bool) (Segment, TTFB) {
+func (o Operations) Total(allThreads bool) Segment {
 	start, end := o.ActiveTimeRange(allThreads)
 	return o.Segment(SegmentOptions{
 		From:           start,
 		PerSegDuration: end.Sub(start) - 1,
 		AllThreads:     allThreads,
-	})[0], o.TTFB(start, end)
+	})[0]
 }
 
 // TTFB returns time to first byte stats for all operations completely within the time segment.

--- a/pkg/bench/analyze.go
+++ b/pkg/bench/analyze.go
@@ -29,6 +29,7 @@ import (
 type SegmentOptions struct {
 	From           time.Time
 	PerSegDuration time.Duration
+	AllThreads     bool
 }
 
 // A Segment represents totals of operations in a specific time segment
@@ -60,11 +61,13 @@ type Segments []Segment
 
 // Total will return the total of active operations.
 // See ActiveTimeRange how this is determined.
-func (o Operations) Total() (Segment, TTFB) {
-	start, end := o.ActiveTimeRange()
+// Specify whether one operation for all threads should be skipped or just a single.
+func (o Operations) Total(allThreads bool) (Segment, TTFB) {
+	start, end := o.ActiveTimeRange(allThreads)
 	return o.Segment(SegmentOptions{
 		From:           start,
 		PerSegDuration: end.Sub(start) - 1,
+		AllThreads:     allThreads,
 	})[0], o.TTFB(start, end)
 }
 
@@ -103,7 +106,7 @@ func (o Operations) TTFB(start, end time.Time) TTFB {
 // Segment will segment the operations o.
 // Operations should be of the same type.
 func (o Operations) Segment(so SegmentOptions) Segments {
-	start, end := o.ActiveTimeRange()
+	start, end := o.ActiveTimeRange(so.AllThreads)
 	if start.After(so.From) {
 		so.From = start
 	}
@@ -216,6 +219,17 @@ func (s Segment) String() string {
 	}
 	return fmt.Sprintf("%s%.02f obj/s, %.02f ops ended/s (%v)",
 		speed, objs, ops, s.EndsBefore.Sub(s.Start).Round(time.Millisecond))
+}
+
+// ShortString returns a string representation of the segment without ops ended/s.
+func (s Segment) ShortString() string {
+	mb, _, objs := s.SpeedPerSec()
+	speed := ""
+	if mb > 0 {
+		speed = fmt.Sprintf("%.02f MB/s, ", mb)
+	}
+	return fmt.Sprintf("%s%.02f obj/s (%v)",
+		speed, objs, s.EndsBefore.Sub(s.Start).Round(time.Millisecond))
 }
 
 // SortByThroughput sorts the segments by throughput.

--- a/pkg/bench/analyze_test.go
+++ b/pkg/bench/analyze_test.go
@@ -44,6 +44,7 @@ func TestOperations_Segment(t *testing.T) {
 		segs := ops.Segment(SegmentOptions{
 			From:           time.Time{},
 			PerSegDuration: time.Second,
+			AllThreads:     true,
 		})
 		t.Log("Operation type:", typ)
 
@@ -54,7 +55,7 @@ func TestOperations_Segment(t *testing.T) {
 		}
 
 		segs.SortByThroughput()
-		totals, ttfb := ops.Total()
+		totals, ttfb := ops.Total(true)
 
 		t.Log("Errors:", len(ops.Errors()))
 		t.Log("Fastest:", segs.Median(1))

--- a/pkg/bench/compare.go
+++ b/pkg/bench/compare.go
@@ -159,7 +159,7 @@ func Compare(before, after Operations, analysis time.Duration) (*Comparison, err
 		if len(segs) <= 1 {
 			return nil, errors.New("too few samples")
 		}
-		totals, _ := ops.Total()
+		totals := ops.Total(true)
 		if totals.TotalBytes > 0 {
 			segs.SortByThroughput()
 		} else {
@@ -180,8 +180,8 @@ func Compare(before, after Operations, analysis time.Duration) (*Comparison, err
 	res.Slowest.Compare(bs.Median(0.0), as.Median(0.0))
 	res.Fastest.Compare(bs.Median(1), as.Median(1))
 
-	beforeTotals, beforeTTFB := before.Total()
-	afterTotals, afterTTFB := after.Total()
+	beforeTotals, beforeTTFB := before.Total(true), before.TTFB(before.TimeRange())
+	afterTotals, afterTTFB := after.Total(true), after.TTFB(after.TimeRange())
 
 	res.Average.Compare(beforeTotals, afterTotals)
 	res.TTFB = beforeTTFB.Compare(afterTTFB)

--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -67,16 +67,18 @@ func (d *Delete) Prepare(ctx context.Context) {
 				default:
 				}
 				obj := src.Object()
+				client := d.Client()
 				op := Operation{
 					OpType:   "PUT",
 					Thread:   uint16(i),
 					Size:     obj.Size,
 					File:     obj.Name,
 					ObjPerOp: 1,
+					Endpoint: client.EndpointURL().String(),
 				}
 				opts.ContentType = obj.ContentType
 				op.Start = time.Now()
-				n, err := d.Client.PutObject(d.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				n, err := client.PutObject(d.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 				op.End = time.Now()
 				if err != nil {
 					console.Fatal("upload error:", err)
@@ -144,16 +146,18 @@ func (d *Delete) Start(ctx context.Context, start chan struct{}) Operations {
 				}
 				close(objects)
 
+				client := d.Client()
 				op := Operation{
 					OpType:   "DELETE",
 					Thread:   uint16(i),
 					Size:     0,
 					File:     "",
 					ObjPerOp: len(objs),
+					Endpoint: client.EndpointURL().String(),
 				}
 				op.Start = time.Now()
 				// RemoveObjectsWithContext will split any batches > 1000 into separate requests.
-				errCh := d.Client.RemoveObjectsWithContext(context.Background(), d.Bucket, objects)
+				errCh := client.RemoveObjectsWithContext(context.Background(), d.Bucket, objects)
 
 				// Wait for errCh to close.
 				for {

--- a/pkg/bench/get.go
+++ b/pkg/bench/get.go
@@ -72,16 +72,18 @@ func (g *Get) Prepare(ctx context.Context) {
 				default:
 				}
 				obj := src.Object()
+				client := g.Client()
 				op := Operation{
 					OpType:   "PUT",
 					Thread:   uint16(i),
 					Size:     obj.Size,
 					File:     obj.Name,
 					ObjPerOp: 1,
+					Endpoint: client.EndpointURL().String(),
 				}
 				opts.ContentType = obj.ContentType
 				op.Start = time.Now()
-				n, err := g.Client.PutObject(g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				n, err := client.PutObject(g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 				op.End = time.Now()
 				if err != nil {
 					console.Fatal("upload error:", err)
@@ -142,16 +144,18 @@ func (g *Get) Start(ctx context.Context, start chan struct{}) Operations {
 				}
 				fbr := firstByteRecorder{}
 				obj := g.objects[rng.Intn(len(g.objects))]
+				client := g.Client()
 				op := Operation{
 					OpType:   "GET",
 					Thread:   uint16(i),
 					Size:     obj.Size,
 					File:     obj.Name,
 					ObjPerOp: 1,
+					Endpoint: client.EndpointURL().String(),
 				}
 				op.Start = time.Now()
 				var err error
-				fbr.r, err = g.Client.GetObject(g.Bucket, obj.Name, opts)
+				fbr.r, err = client.GetObject(g.Bucket, obj.Name, opts)
 				if err != nil {
 					console.Errorln("download error:", err)
 					op.Err = err.Error()

--- a/pkg/bench/list.go
+++ b/pkg/bench/list.go
@@ -78,16 +78,18 @@ func (d *List) Prepare(ctx context.Context) {
 					break
 				}
 				exists[obj.Name] = struct{}{}
+				client := d.Client()
 				op := Operation{
 					OpType:   "PUT",
 					Thread:   uint16(i),
 					Size:     obj.Size,
 					File:     obj.Name,
 					ObjPerOp: 1,
+					Endpoint: client.EndpointURL().String(),
 				}
 				opts.ContentType = obj.ContentType
 				op.Start = time.Now()
-				n, err := d.Client.PutObject(d.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				n, err := client.PutObject(d.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 				op.End = time.Now()
 				if err != nil {
 					console.Fatal("upload error:", err)
@@ -140,16 +142,18 @@ func (d *List) Start(ctx context.Context, start chan struct{}) Operations {
 				}
 
 				prefix := objs[0].PreFix
+				client := d.Client()
 				op := Operation{
-					File:   prefix,
-					OpType: "LIST",
-					Thread: uint16(i),
-					Size:   0,
+					File:     prefix,
+					OpType:   "LIST",
+					Thread:   uint16(i),
+					Size:     0,
+					Endpoint: client.EndpointURL().String(),
 				}
 				op.Start = time.Now()
 
 				// List all objects with prefix
-				listCh := d.Client.ListObjectsV2(d.Bucket, objs[0].PreFix, true, nil)
+				listCh := client.ListObjectsV2(d.Bucket, objs[0].PreFix, true, nil)
 
 				// Wait for errCh to close.
 				for {

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -58,15 +58,17 @@ func (u *Put) Start(ctx context.Context, start chan struct{}) Operations {
 				}
 				obj := src.Object()
 				opts.ContentType = obj.ContentType
+				client := u.Client()
 				op := Operation{
 					OpType:   "PUT",
 					Thread:   uint16(i),
 					Size:     obj.Size,
 					File:     obj.Name,
 					ObjPerOp: 1,
+					Endpoint: client.EndpointURL().String(),
 				}
 				op.Start = time.Now()
-				n, err := u.Client.PutObject(u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				n, err := client.PutObject(u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 				op.End = time.Now()
 				if err != nil {
 					console.Errorln("upload error:", err)


### PR DESCRIPTION
Allows to specify multiple endpoints by setting host to a comma separated list.

Records which endpoint is being used.

Example output:
```
λ warp analyze warp-get-2019-11-29[124533]-HOhm.csv.zst    
-------------------                                                    
Operation: PUT. Concurrency: 12. Hosts: 7.                             
* Average: 39.50 MB/s, 39.50 obj/s, 39.51 ops ended/s (1m2.244s)       
Hosts:                                                                 
 * http://127.0.0.1:9001: Avg: 5.58 MB/s, 5.58 obj/s (53.256s)         
 * http://127.0.0.1:9002: Avg: 5.60 MB/s, 5.60 obj/s (54.329s)         
 * http://127.0.0.1:9003: Avg: 5.55 MB/s, 5.55 obj/s (56.811s)         
 * http://127.0.0.1:9004: Avg: 5.65 MB/s, 5.65 obj/s (50.297s)         
 * http://127.0.0.1:9005: Avg: 5.70 MB/s, 5.70 obj/s (51.875s)         
 * http://127.0.0.1:9006: Avg: 5.37 MB/s, 5.37 obj/s (45.709s)         
 * http://127.0.0.1:9007: Avg: 5.53 MB/s, 5.53 obj/s (52.872s)         
                                                                       
Aggregated, split into 62 x 1s time segments:                          
* Fastest: 86.35 MB/s, 86.35 obj/s, 88.00 ops ended/s (1s)             
* 50% Median: 35.92 MB/s, 35.92 obj/s, 33.00 ops ended/s (1s)          
* Slowest: 25.38 MB/s, 25.38 obj/s, 23.00 ops ended/s (1s)             
```

### Per request statistics

By adding the `-requests` parameter it is possible to display per request statistics.

This is not enabled by default, since it is assumed the benchmarks are throughput limited, 
but in certain scenarios it can be useful to determine problems with individual hosts for instance.

Example:

```
Operation: GET. Concurrency: 12. Hosts: 7.                                                       
                                                                                                 
Requests - 16720:                                                                                
 * Fastest: 2.9965ms Slowest: 62.9993ms 50%: 21.0006ms 90%: 31.0021ms 99%: 41.0016ms             
 * First Byte: Average: 20.575134ms, Median: 20.0007ms, Best: 1.9985ms, Worst: 62.9993ms         
                                                                                                 
Requests by host:                                                                                
 * http://127.0.0.1:9001 - 2395 requests:                                                        
        - Fastest: 2.9965ms Slowest: 55.0015ms 50%: 18.0002ms 90%: 28.001ms                      
        - First Byte: Average: 17.139147ms, Median: 16.9998ms, Best: 1.9985ms, Worst: 53.0026ms  
 * http://127.0.0.1:9002 - 2395 requests:                                                        
        - Fastest: 4.999ms Slowest: 60.9925ms 50%: 20.9993ms 90%: 31.001ms                       
        - First Byte: Average: 20.174683ms, Median: 19.9996ms, Best: 3.999ms, Worst: 59.9912ms   
 * http://127.0.0.1:9003 - 2395 requests:                                                        
        - Fastest: 6.9988ms Slowest: 56.0005ms 50%: 20.9978ms 90%: 31.001ms                      
        - First Byte: Average: 20.272876ms, Median: 19.9983ms, Best: 5.0012ms, Worst: 55.0012ms  
 * http://127.0.0.1:9004 - 2395 requests:                                                        
        - Fastest: 5.0002ms Slowest: 62.9993ms 50%: 22.0009ms 90%: 33.001ms                      
        - First Byte: Average: 22.039164ms, Median: 21.0015ms, Best: 4.0003ms, Worst: 62.9993ms  
 * http://127.0.0.1:9005 - 2396 requests:                                                        
        - Fastest: 6.9934ms Slowest: 54.002ms 50%: 21.0008ms 90%: 30.9998ms                      
        - First Byte: Average: 20.871833ms, Median: 20.0006ms, Best: 4.9998ms, Worst: 52.0019ms  
 * http://127.0.0.1:9006 - 2396 requests:                                                        
        - Fastest: 6.0019ms Slowest: 54.9972ms 50%: 22.9985ms 90%: 33.0007ms                     
        - First Byte: Average: 22.430863ms, Median: 21.9986ms, Best: 5.0008ms, Worst: 53.9981ms  
 * http://127.0.0.1:9007 - 2396 requests:                                                        
        - Fastest: 7.9968ms Slowest: 55.0899ms 50%: 21.998ms 90%: 30.9998ms                      
        - First Byte: Average: 21.049681ms, Median: 20.9989ms, Best: 6.9958ms, Worst: 54.0884ms  
```
