### PR TITLE
Add per host aggregation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,32 @@ Aggregated, split into 59 x 1s time segments:
 * 50% Median: 2419.56 MB/s, 241.96 obj/s, 240.00 ops ended/s (1s)
 * Slowest: 1137.36 MB/s, 113.74 obj/s, 112.00 ops ended/s (1s)
 ```
+
+### Analysis Parameters
+
+Beside the important `-analysis.dur` which specifies the time segment size for aggregated data
+there are some additional parameters that can be used.
+
+Specifying `-analyze.hostdetails` will output time aggregated data per host instead of just averages. 
+For instance:
+
+```
+Throughput by host:
+ * http://127.0.0.1:9001: Avg: 81.48 MB/s, 81.48 obj/s (4m59.976s)
+        - Fastest: 86.46 MB/s, 86.46 obj/s (1s)
+        - 50% Median: 82.23 MB/s, 82.23 obj/s (1s)
+        - Slowest: 68.14 MB/s, 68.14 obj/s (1s)
+ * http://127.0.0.1:9002: Avg: 81.48 MB/s, 81.48 obj/s (4m59.968s)
+        - Fastest: 87.36 MB/s, 87.36 obj/s (1s)
+        - 50% Median: 82.28 MB/s, 82.28 obj/s (1s)
+        - Slowest: 68.40 MB/s, 68.40 obj/s (1s)
+```
+
+
+`-analyze.op=GET` will only analyze GET operations.
+
+Specifying `-analyze.host=http://127.0.0.1:9001` will only consider data from this specific host. 
+
 ### Per request statistics
 
 By adding the `-requests` parameter it is possible to display per request statistics.
@@ -226,6 +252,7 @@ These are the data fields exported:
 |---------------------|-------------|
 | `index`             | Index of the segment  |
 | `op`                | Operation executed  |
+| `host`              | If only one host, host name, otherwise empty  |
 | `duration_s`        | Duration of the segment in seconds  |
 | `objects_per_op`    | Objects per operation  |
 | `bytes`             | Total bytes of operations (*distributed)  |

--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ Throughput by host:
 
 Specifying `-analyze.host=http://127.0.0.1:9001` will only consider data from this specific host. 
 
+Warp will automatically discard the time taking the first and last request of all threads to finish.
+However, if you would like to discard additional time from the aggregated data, 
+this is possible. For instance `analyze.skip=10s` will skip the first 10 seconds of data for each operation type.
+
+Note that skipping data will not always result in the exact reduction in time for the aggregated data
+since the start time will still be aligned with requests starting. 
+
 ### Per request statistics
 
 By adding the `-requests` parameter it is possible to display per request statistics.

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -54,6 +54,12 @@ var analyzeFlags = []cli.Flag{
 		Value: "",
 		Usage: "Only output for this host.",
 	},
+	cli.DurationFlag{
+		Name:   "analyze.skip",
+		Usage:  "Additional duration to skip when analyzing data.",
+		Hidden: false,
+		Value:  0,
+	},
 	cli.BoolFlag{
 		Name:  "analyze.hostdetails",
 		Usage: "Do detailed time segmentation per host",
@@ -147,6 +153,11 @@ func printAnalysis(ctx *cli.Context, ops bench.Operations) {
 			}
 		}
 		ops := ops.FilterByOp(typ)
+		if d := ctx.Duration("analyze.skip"); d > 0 {
+			start, end := ops.TimeRange()
+			start = start.Add(d)
+			ops = ops.FilterInsideRange(start, end)
+		}
 		console.Println("-------------------")
 		segs := ops.Segment(bench.SegmentOptions{
 			From:           time.Time{},

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -191,6 +191,10 @@ func printAnalysis(ctx *cli.Context, ops bench.Operations) {
 				totals := ops.FilterByEndpoint(ep).Total(false)
 				console.SetColor("Print", color.New(color.FgWhite))
 				console.Print(" * ", ep, ": Avg: ", totals.ShortString(), "\n")
+				if errs := ops.Errors(); len(errs) > 0 {
+					console.SetColor("Print", color.New(color.FgHiRed))
+					console.Println("Errors:", len(errs))
+				}
 				if hostDetails {
 					ops := ops.FilterByEndpoint(ep)
 					segs := ops.Segment(bench.SegmentOptions{
@@ -198,6 +202,7 @@ func printAnalysis(ctx *cli.Context, ops bench.Operations) {
 						PerSegDuration: analysisDur(ctx),
 						AllThreads:     true,
 					})
+					console.SetColor("Print", color.New(color.FgWhite))
 					if len(segs) <= 1 {
 						console.Println("Skipping", typ, "host:", ep, " - Too few samples.")
 						continue

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -49,6 +49,15 @@ var analyzeFlags = []cli.Flag{
 		Value: "",
 		Usage: "Only output for this op. Can be GET/PUT/DELETE, etc.",
 	},
+	cli.StringFlag{
+		Name:  "analyze.host",
+		Value: "",
+		Usage: "Only output for this host.",
+	},
+	cli.BoolFlag{
+		Name:  "analyze.hostdetails",
+		Usage: "Do detailed time segmentation per host",
+	},
 	cli.BoolFlag{
 		Name:  "requests",
 		Usage: "Display individual request stats.",
@@ -124,6 +133,11 @@ func printAnalysis(ctx *cli.Context, ops bench.Operations) {
 			wrSegs = f
 		}
 	}
+	if onlyHost := ctx.String("analyze.host"); onlyHost != "" {
+		ops = ops.FilterByEndpoint(onlyHost)
+	}
+	hostDetails := ctx.Bool("analyze.hostdetails") && ops.Hosts() > 1
+
 	ops.SortByStartTime()
 	types := ops.OpTypes()
 	for _, typ := range types {
@@ -176,8 +190,29 @@ func printAnalysis(ctx *cli.Context, ops bench.Operations) {
 			for _, ep := range eps {
 				totals := ops.FilterByEndpoint(ep).Total(false)
 				console.SetColor("Print", color.New(color.FgWhite))
-				console.Print(" * ", ep, ": Avg: ", totals.ShortString())
-				console.Println("")
+				console.Print(" * ", ep, ": Avg: ", totals.ShortString(), "\n")
+				if hostDetails {
+					ops := ops.FilterByEndpoint(ep)
+					segs := ops.Segment(bench.SegmentOptions{
+						From:           time.Time{},
+						PerSegDuration: analysisDur(ctx),
+						AllThreads:     true,
+					})
+					if len(segs) <= 1 {
+						console.Println("Skipping", typ, "host:", ep, " - Too few samples.")
+						continue
+					}
+					totals := ops.Total(true)
+					if totals.TotalBytes > 0 {
+						segs.SortByThroughput()
+					} else {
+						segs.SortByObjsPerSec()
+					}
+					console.SetColor("Print", color.New(color.FgWhite))
+					console.Println("\t- Fastest:", segs.Median(1).ShortString())
+					console.Println("\t- 50% Median:", segs.Median(0.5).ShortString())
+					console.Println("\t- Slowest:", segs.Median(0.0).ShortString())
+				}
 			}
 		}
 		console.SetColor("Print", color.New(color.FgHiWhite))
@@ -190,6 +225,31 @@ func printAnalysis(ctx *cli.Context, ops bench.Operations) {
 			segs.SortByTime()
 			err := segs.CSV(wrSegs)
 			errorIf(probe.NewError(err), "Error writing analysis")
+
+			// Write segments per endpoint
+			eps := ops.Endpoints()
+			if hostDetails && len(eps) > 1 {
+				for _, ep := range eps {
+					ops := ops.FilterByEndpoint(ep)
+					segs := ops.Segment(bench.SegmentOptions{
+						From:           time.Time{},
+						PerSegDuration: analysisDur(ctx),
+						AllThreads:     true,
+					})
+					if len(segs) <= 1 {
+						continue
+					}
+					totals := ops.Total(true)
+					if totals.TotalBytes > 0 {
+						segs.SortByThroughput()
+					} else {
+						segs.SortByObjsPerSec()
+					}
+					segs.SortByTime()
+					err := segs.CSV(wrSegs)
+					errorIf(probe.NewError(err), "Error writing analysis")
+				}
+			}
 		}
 	}
 }

--- a/pkg/bench/compare.go
+++ b/pkg/bench/compare.go
@@ -53,6 +53,8 @@ func (c *CmpSegment) Compare(before, after Segment) {
 	c.OpsEndedPerSec = 100 * (opsA - opsB) / opsB
 	if mbB > 0 {
 		c.ThroughputPerSec = 100 * (mbA - mbB) / mbB
+	} else {
+		c.ThroughputPerSec = 0
 	}
 }
 
@@ -62,7 +64,7 @@ func (c CmpSegment) String() string {
 	mbB, _, objsB := c.Before.SpeedPerSec()
 	mbA, _, objsA := c.After.SpeedPerSec()
 
-	if c.ThroughputPerSec > 0 {
+	if c.ThroughputPerSec != 0 {
 		speed = fmt.Sprintf("%s%.02f%% (%s%.1f MB/s) throughput, ",
 			plusPositiveF(c.ThroughputPerSec), c.ThroughputPerSec,
 			plusPositiveF(c.ThroughputPerSec), mbA-mbB,
@@ -70,7 +72,7 @@ func (c CmpSegment) String() string {
 	}
 	return fmt.Sprintf("%s%s%.02f%% (%s%.1f) obj/s",
 		speed, plusPositiveF(c.ObjPerSec), c.ObjPerSec,
-		plusPositiveF(c.ObjPerSec), objsA-objsB,
+		plusPositiveF(objsA-objsB), objsA-objsB,
 	)
 }
 

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -214,6 +214,7 @@ func (o Operations) FilterByHasTTFB(hasTTFB bool) Operations {
 }
 
 // FilterInsideRange returns operations that are inside the specified time range.
+// Operations starting before start or ending after end are discarded.
 func (o Operations) FilterInsideRange(start, end time.Time) Operations {
 	dst := make(Operations, 0, len(o))
 	for _, o := range o {


### PR DESCRIPTION
Adds optional per host aggregated data. Optional with `-analyze.hostdetails` since it also spits out a lot to CSV.

Example
```
Throughput by host:                                                
 * http://127.0.0.1:9001: Avg: 81.48 MB/s, 81.48 obj/s (4m59.976s) 
        - Fastest: 86.46 MB/s, 86.46 obj/s (1s)                    
        - 50% Median: 82.23 MB/s, 82.23 obj/s (1s)                 
        - Slowest: 68.14 MB/s, 68.14 obj/s (1s)                    
 * http://127.0.0.1:9002: Avg: 81.48 MB/s, 81.48 obj/s (4m59.968s) 
        - Fastest: 87.36 MB/s, 87.36 obj/s (1s)                    
        - 50% Median: 82.28 MB/s, 82.28 obj/s (1s)                 
        - Slowest: 68.40 MB/s, 68.40 obj/s (1s)                    
 * http://127.0.0.1:9003: Avg: 81.48 MB/s, 81.48 obj/s (4m59.978s) 
        - Fastest: 86.98 MB/s, 86.98 obj/s (1s)                    
        - 50% Median: 82.26 MB/s, 82.26 obj/s (1s)                 
        - Slowest: 67.63 MB/s, 67.63 obj/s (1s)                    
 * http://127.0.0.1:9004: Avg: 81.47 MB/s, 81.47 obj/s (4m59.978s) 
        - Fastest: 86.90 MB/s, 86.90 obj/s (1s)                    
        - 50% Median: 82.32 MB/s, 82.32 obj/s (1s)                 
        - Slowest: 68.05 MB/s, 68.05 obj/s (1s)                    
 * http://127.0.0.1:9005: Avg: 81.48 MB/s, 81.48 obj/s (4m59.965s) 
        - Fastest: 86.67 MB/s, 86.67 obj/s (1s)                    
        - 50% Median: 82.08 MB/s, 82.08 obj/s (1s)                 
        - Slowest: 67.64 MB/s, 67.64 obj/s (1s)                    
 * http://127.0.0.1:9006: Avg: 81.47 MB/s, 81.47 obj/s (4m59.98s)  
        - Fastest: 87.18 MB/s, 87.18 obj/s (1s)                    
        - 50% Median: 82.18 MB/s, 82.18 obj/s (1s)                 
        - Slowest: 66.22 MB/s, 66.22 obj/s (1s)                    
 * http://127.0.0.1:9007: Avg: 81.48 MB/s, 81.48 obj/s (4m59.96s)  
        - Fastest: 86.87 MB/s, 86.87 obj/s (1s)                    
        - 50% Median: 82.17 MB/s, 82.17 obj/s (1s)                 
        - Slowest: 68.34 MB/s, 68.34 obj/s (1s)                    
```

Data is added to csv output if specified.

Add `-analyze.host` to allow to analyze data from a single host fully.