### PR TITLE
Add weighed host selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ The S3 server to use can be specified on the commandline using `-host`, `-access
 
 It is also possible to set the same parameters using the `WARP_HOST`, `WARP_ACCESS_KEY`, `WARP_SECRET_KEY` and `WARP_TLS` environment variables.
 
-Multiple hosts can be specified as comma-separated values, for instance `10.0.0.1:9000,10.0.0.2:9000` 
-will do a round-robin between the specified servers. 
-
-Alternatively numerical ranges can be specified using `10.0.0.{1...10}:9000` which will add `10.0.0.1` through `10.0.0.10`.
-This syntax can be used for any part of the host name and port.  
- 
 The credentials must be able to create, delete and list buckets and upload files and perform the operation requested.
 
 By default operations are performed on a bucket called `warp-benchmark-bucket`.
@@ -24,8 +18,9 @@ This can be changed using the `-bucket` parameter.
 Do however note that the bucket will be completely cleaned before and after each run, 
 so it should *not* contain any data.
 
-If you are running TLS, you can enable server-side-encryption of objects using `-encrypt`. 
-A random key will be generated and used.
+If you are [running TLS](https://docs.min.io/docs/how-to-secure-access-to-minio-server-with-tls.html), 
+you can enable [server-side-encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) of objects using `-encrypt`. 
+A random key will be generated and used for objects.
 
 # usage
 
@@ -45,12 +40,28 @@ By default all benchmarks save all request details to a file named `warp-operati
 A custom file name can be specified using the `-benchdata` parameter.
 The raw data is [zstandard](https://facebook.github.io/zstd/) compressed CSV data.
 
+## multiple hosts
+
+Multiple hosts can be specified as comma-separated values, for instance `10.0.0.1:9000,10.0.0.2:9000` 
+will switch between the specified servers. 
+
+Alternatively numerical ranges can be specified using `10.0.0.{1...10}:9000` which will add `10.0.0.1` through `10.0.0.10`.
+This syntax can be used for any part of the host name and port.  
+
+By default a random host is chosen between the hosts that have the least number of requests running. 
+This will ensure that in cases where hosts operate at different speeds that the fastest servers will get the most requests.
+It is possible to choose a simple round-robin algorithm by using the `-host-select=roundrobin` parameter.
+If there is only one host this parameter has no effect.   
+
 When running benchmarks on several clients, it is possible to synchronize their start time 
 using the `-syncstart` parameter.
 The time format is 'hh:mm' where hours are specified in 24h format, and parsed as local server time.
 Using this will make it more reliable to [merge benchmarks](https://github.com/minio/warp#merging-benchmarks) 
 from the clients for total result. 
- 
+
+When benchmarks are done per host averages will be printed out. 
+For further details, the `-analyze.hostdetails` parameter can also be used. 
+
 ## get
 
 Benchmarking get operations will upload `-objects` objects of size `-obj.size` and attempt to 
@@ -132,7 +143,7 @@ Aggregated, split into 59 x 1s time segments:
 * Slowest: 27917.33 obj/s, 35.00 ops ended/s (1s)
 ```
 
-# Analysis
+# analysis
 
 When benchmarks have finished all request data will be saved to a file and an analysis will be shown.
 
@@ -144,7 +155,7 @@ Only the time segments that was actually overlapping will be considered.
 This is based on the absolute time of each recording, 
 so be sure that clocks are reasonably synchronized or use the `-syncstart` parameter.  
 
-## Analysis data
+## analysis data
 
 All analysis will be done on a reduced part of the full data. 
 The data aggregation will *start* when all threads have completed one request and 
@@ -171,7 +182,7 @@ Aggregated, split into 59 x 1s time segments:
 * Slowest: 1137.36 MB/s, 113.74 obj/s, 112.00 ops ended/s (1s)
 ```
 
-### Analysis Parameters
+### analysis parameters
 
 Beside the important `-analysis.dur` which specifies the time segment size for aggregated data
 there are some additional parameters that can be used.
@@ -203,7 +214,7 @@ this is possible. For instance `analyze.skip=10s` will skip the first 10 seconds
 Note that skipping data will not always result in the exact reduction in time for the aggregated data
 since the start time will still be aligned with requests starting. 
 
-### Per request statistics
+### per request statistics
 
 By adding the `-requests` parameter it is possible to display per request statistics.
 
@@ -247,7 +258,7 @@ The fastest and slowest request times are shown, as well as selected percentiles
 
 Note that different metrics are used to select the number of requests per host and for the combined, so there will likely be differences.
 
-### CSV output
+### csv output
 
 It is possible to output the CSV data of analysis using `-analyze.out=filename.csv` 
 which will write the CSV data to the specified file. 
@@ -279,7 +290,7 @@ The bigger a percentage of the operation is within a segment the larger part of 
 
 This is why there can be a partial object attributed to a segment, because only a part of the operation took place in the segment.
 
-## Comparing Benchmarks
+## comparing benchmarks
 
 It is possible to compare two recorded runs using the `warp cmp (file-before) (file-after)` to
 see the differences between before and after. 
@@ -312,7 +323,7 @@ Differences in parameters will be shown.
 
 The usual analysis parameters can be applied to define segment lengths.
 
-## Merging benchmarks
+## merging benchmarks
 
 It is possible to merge runs from several clients using the `warp merge (file1) (file2) [additional files...]` command.
 
@@ -326,7 +337,7 @@ It is important to note that only data that strictly overlaps in absolute time w
 When running benchmarks on several clients it is likely a good idea to specify the `-noclear` parameter so
 clients don't accidentally delete each others data on startup or shutdown.
 
-# Server Profiling
+# server profiling
 
 When running against a MinIO server it is possible to enable profiling while the benchmark is running.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ will switch between the specified servers.
 Alternatively numerical ranges can be specified using `10.0.0.{1...10}:9000` which will add `10.0.0.1` through `10.0.0.10`.
 This syntax can be used for any part of the host name and port.  
 
-By default a random host is chosen between the hosts that have the least number of requests running. 
+By default a host is chosen between the hosts that have the least number of requests running and with the longest time since the last request finished. 
 This will ensure that in cases where hosts operate at different speeds that the fastest servers will get the most requests.
 It is possible to choose a simple round-robin algorithm by using the `-host-select=roundrobin` parameter.
 If there is only one host this parameter has no effect.   

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -211,14 +211,14 @@ func printAnalysis(ctx *cli.Context, ops bench.Operations) {
 					segs := ops.Segment(bench.SegmentOptions{
 						From:           time.Time{},
 						PerSegDuration: analysisDur(ctx),
-						AllThreads:     true,
+						AllThreads:     false,
 					})
 					console.SetColor("Print", color.New(color.FgWhite))
 					if len(segs) <= 1 {
 						console.Println("Skipping", typ, "host:", ep, " - Too few samples.")
 						continue
 					}
-					totals := ops.Total(true)
+					totals := ops.Total(false)
 					if totals.TotalBytes > 0 {
 						segs.SortByThroughput()
 					} else {

--- a/cli/client.go
+++ b/cli/client.go
@@ -3,8 +3,13 @@ package cli
 import (
 	"errors"
 	"log"
+	"math"
+	"math/rand"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/minio/mc/pkg/console"
 
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/probe"
@@ -36,7 +41,14 @@ func parseHosts(h string) []string {
 	return dst
 }
 
-func newClient(ctx *cli.Context) func() *minio.Client {
+type hostSelectType string
+
+const (
+	hostSelectTypeRoundrobin hostSelectType = "roundrobin"
+	hostSelectTypeWeighed    hostSelectType = "weighed"
+)
+
+func newClient(ctx *cli.Context) func() (cl *minio.Client, done func()) {
 	hosts := parseHosts(ctx.String("host"))
 	switch len(hosts) {
 	case 0:
@@ -45,28 +57,94 @@ func newClient(ctx *cli.Context) func() *minio.Client {
 		cl, err := minio.New(hosts[0], ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
 		fatalIf(probe.NewError(err), "Unable to create MinIO client")
 		cl.SetAppInfo(appName, pkg.Version)
-		return func() *minio.Client {
-			return cl
+		return func() (*minio.Client, func()) {
+			return cl, func() {}
 		}
 	}
-	// Do round-robin.
-	var current int
-	var mu sync.Mutex
-	clients := make([]*minio.Client, len(hosts))
-	for i := range hosts {
-		cl, err := minio.New(hosts[i], ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
-		fatalIf(probe.NewError(err), "Unable to create MinIO client")
-		cl.SetAppInfo(appName, pkg.Version)
-		clients[i] = cl
+	hostSelect := hostSelectType(ctx.String("host-select"))
+	switch hostSelect {
+	case hostSelectTypeRoundrobin:
+		// Do round-robin.
+		var current int
+		var mu sync.Mutex
+		clients := make([]*minio.Client, len(hosts))
+		for i := range hosts {
+			cl, err := minio.New(hosts[i], ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
+			fatalIf(probe.NewError(err), "Unable to create MinIO client")
+			cl.SetAppInfo(appName, pkg.Version)
+			clients[i] = cl
+		}
+		return func() (*minio.Client, func()) {
+			mu.Lock()
+			now := current % len(clients)
+			current++
+			mu.Unlock()
+			return clients[now], func() {}
+		}
+	case hostSelectTypeWeighed:
+		// Keep track of handed out clients.
+		// Select random between the clients that have the fewest handed out.
+		var mu sync.Mutex
+		clients := make([]*minio.Client, len(hosts))
+		for i := range hosts {
+			cl, err := minio.New(hosts[i], ctx.String("access-key"), ctx.String("secret-key"), ctx.Bool("tls"))
+			fatalIf(probe.NewError(err), "Unable to create MinIO client")
+			cl.SetAppInfo(appName, pkg.Version)
+			clients[i] = cl
+		}
+		running := make([]int, len(hosts))
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		find := func() int {
+			min := math.MaxInt32
+			for _, n := range running {
+				if n < min {
+					min = n
+				}
+			}
+			nEligible := 0
+			for _, n := range running {
+				if n == min {
+					nEligible++
+				}
+			}
+			// Only one, return that
+			if nEligible == 1 {
+				for i, n := range running {
+					if n == min {
+						return i
+					}
+				}
+			}
+			choose := rng.Intn(nEligible)
+			for i, n := range running {
+				if n == min {
+					if choose == 0 {
+						return i
+					}
+					choose--
+				}
+			}
+			// Unless we have a race, this should not be hit.
+			panic("internal error: could not find client")
+		}
+		return func() (*minio.Client, func()) {
+			mu.Lock()
+			idx := find()
+			running[idx]++
+			mu.Unlock()
+			return clients[idx], func() {
+				mu.Lock()
+				running[idx]--
+				if running[idx] < 0 {
+					// Will happen if done is called twice.
+					panic("client running index < 0")
+				}
+				mu.Unlock()
+			}
+		}
 	}
-	return func() *minio.Client {
-		mu.Lock()
-		now := current % len(clients)
-		current++
-		mu.Unlock()
-		return clients[now]
-
-	}
+	console.Fatalln("unknown host-select:", hostSelect)
+	return nil
 }
 
 func newAdminClient(ctx *cli.Context) *madmin.AdminClient {

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -17,6 +17,7 @@
 package cli
 
 import (
+	"fmt"
 	"runtime"
 
 	"github.com/minio/cli"
@@ -145,6 +146,11 @@ var ioFlags = []cli.Flag{
 		Name:  "bucket",
 		Value: appName + "-benchmark-bucket",
 		Usage: "Bucket to use for benchmark data. ALL DATA WILL BE DELETED IN BUCKET!",
+	},
+	cli.StringFlag{
+		Name:  "host-select",
+		Value: string(hostSelectTypeWeighed),
+		Usage: fmt.Sprintf("Host selection algorithm. Can be %q or %q", hostSelectTypeWeighed, hostSelectTypeRoundrobin),
 	},
 	cli.IntFlag{
 		Name:  "concurrent",

--- a/pkg/bench/analyze_test.go
+++ b/pkg/bench/analyze_test.go
@@ -55,7 +55,8 @@ func TestOperations_Segment(t *testing.T) {
 		}
 
 		segs.SortByThroughput()
-		totals, ttfb := ops.Total(true)
+		totals := ops.Total(true)
+		ttfb := ops.TTFB(ops.ActiveTimeRange(true))
 
 		t.Log("Errors:", len(ops.Errors()))
 		t.Log("Fastest:", segs.Median(1))

--- a/pkg/bench/compare.go
+++ b/pkg/bench/compare.go
@@ -146,7 +146,7 @@ func plusPositiveD(d time.Duration) string {
 func Compare(before, after Operations, analysis time.Duration) (*Comparison, error) {
 	var res Comparison
 	if before.FirstOpType() != after.FirstOpType() {
-		return nil, fmt.Errorf("different operation types. before: %v, after %d", before.FirstOpType(), after.FirstOpType())
+		return nil, fmt.Errorf("different operation types. before: %v, after %v", before.FirstOpType(), after.FirstOpType())
 	}
 	if len(before.Errors()) > 0 || len(after.Errors()) > 0 {
 		return nil, fmt.Errorf("errors recorded in benchmark run. before: %v, after %d", len(before.Errors()), len(after.Errors()))

--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -67,7 +67,7 @@ func (d *Delete) Prepare(ctx context.Context) {
 				default:
 				}
 				obj := src.Object()
-				client := d.Client()
+				client, cldone := d.Client()
 				op := Operation{
 					OpType:   "PUT",
 					Thread:   uint16(i),
@@ -86,6 +86,7 @@ func (d *Delete) Prepare(ctx context.Context) {
 				if n != obj.Size {
 					console.Fatal("short upload. want:", obj.Size, ", got:", n)
 				}
+				cldone()
 				mu.Lock()
 				obj.Reader = nil
 				d.objects = append(d.objects, *obj)
@@ -146,7 +147,7 @@ func (d *Delete) Start(ctx context.Context, start chan struct{}) Operations {
 				}
 				close(objects)
 
-				client := d.Client()
+				client, cldone := d.Client()
 				op := Operation{
 					OpType:   "DELETE",
 					Thread:   uint16(i),
@@ -171,6 +172,7 @@ func (d *Delete) Start(ctx context.Context, start chan struct{}) Operations {
 					}
 				}
 				op.End = time.Now()
+				cldone()
 				rcv <- op
 			}
 		}(i)

--- a/pkg/bench/list.go
+++ b/pkg/bench/list.go
@@ -78,7 +78,7 @@ func (d *List) Prepare(ctx context.Context) {
 					break
 				}
 				exists[obj.Name] = struct{}{}
-				client := d.Client()
+				client, cldone := d.Client()
 				op := Operation{
 					OpType:   "PUT",
 					Thread:   uint16(i),
@@ -97,6 +97,7 @@ func (d *List) Prepare(ctx context.Context) {
 				if n != obj.Size {
 					console.Fatal("short upload. want:", obj.Size, ", got:", n)
 				}
+				cldone()
 				mu.Lock()
 				obj.Reader = nil
 				d.objects[i] = append(d.objects[i], *obj)
@@ -142,7 +143,7 @@ func (d *List) Start(ctx context.Context, start chan struct{}) Operations {
 				}
 
 				prefix := objs[0].PreFix
-				client := d.Client()
+				client, cldone := d.Client()
 				op := Operation{
 					File:     prefix,
 					OpType:   "LIST",
@@ -177,6 +178,7 @@ func (d *List) Start(ctx context.Context, start chan struct{}) Operations {
 					}
 				}
 				op.End = time.Now()
+				cldone()
 				rcv <- op
 			}
 		}(i)

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -58,7 +58,7 @@ func (u *Put) Start(ctx context.Context, start chan struct{}) Operations {
 				}
 				obj := src.Object()
 				opts.ContentType = obj.ContentType
-				client := u.Client()
+				client, cldone := u.Client()
 				op := Operation{
 					OpType:   "PUT",
 					Thread:   uint16(i),
@@ -81,6 +81,7 @@ func (u *Put) Start(ctx context.Context, start chan struct{}) Operations {
 					}
 					console.Errorln(err)
 				}
+				cldone()
 				rcv <- op
 			}
 		}(i)


### PR DESCRIPTION
In addition to standard round-robin add a weighed host selection.

The host chosen for a request will be a host that has the least number of requests running.

For hosts with a similar number of requests running, the one that finished the last request the longest ago is chosen. This should ensure close a good distribution.

Enabled by default.

Operations are still pretty fair:
```
Operation: GET. Concurrency: 12. Hosts: 4.                                                            
                                                                                                      
Requests - 3666:                                                                                      
 * Fastest: 29.921ms Slowest: 641.2862ms 50%: 95.7416ms 90%: 127.6601ms 99%: 164.5584ms               
 * First Byte: Average: 73.532504ms, Median: 71.8083ms, Best: 10.9695ms, Worst: 613.3605ms            
                                                                                                      
Requests by host:                                                                                     
 * http://127.0.0.1:9001 - 1064 requests:                                                             
        - Fastest: 23.9391ms Slowest: 188.4956ms 50%: 84.7727ms 90%: 115.6896ms                       
        - First Byte: Average: 61.393093ms, Median: 61.834ms, Best: 7.9798ms, Worst: 168.5497ms       
 * http://127.0.0.1:9002 - 889 requests:                                                              
        - Fastest: 40.8926ms Slowest: 641.2862ms 50%: 98.7375ms 90%: 131.6471ms                       
        - First Byte: Average: 78.252004ms, Median: 75.7971ms, Best: 21.9419ms, Worst: 613.3605ms     
 * http://127.0.0.1:9003 - 864 requests:                                                              
        - Fastest: 38.899ms Slowest: 509.636ms 50%: 100.7324ms 90%: 133.6452ms                        
        - First Byte: Average: 80.2657ms, Median: 76.7948ms, Best: 18.9512ms, Worst: 493.6785ms       
 * http://127.0.0.1:9004 - 902 requests:                                                              
        - Fastest: 45.8768ms Slowest: 317.1537ms 50%: 98.733ms 90%: 129.6477ms                        
        - First Byte: Average: 76.671972ms, Median: 74.8005ms, Best: 26.9286ms, Worst: 298.2052ms     
```                                                                                                         