### PR TITLE
Add random sized objects

### DIFF
--- a/cli/generator.go
+++ b/cli/generator.go
@@ -35,6 +35,10 @@ var genFlags = []cli.Flag{
 		Value: "random",
 		Usage: "Use specific data generator",
 	},
+	cli.BoolFlag{
+		Name:  "obj.randsize",
+		Usage: "Randomize size of objects so they will be up to the specified size",
+	},
 }
 
 // newGenSource returns a new generator
@@ -60,6 +64,7 @@ func newGenSource(ctx *cli.Context) func() generator.Source {
 	src, err := generator.NewFn(g.Apply(),
 		generator.WithPrefixSize(prefixSize),
 		generator.WithSize(int64(size)),
+		generator.WithRandomSize(ctx.Bool("obj.randsize")),
 	)
 	fatalIf(probe.NewError(err), "Unable to create data generator")
 	return src

--- a/pkg/generator/circular.go
+++ b/pkg/generator/circular.go
@@ -32,7 +32,13 @@ type circularBuffer struct {
 	read int64
 }
 
-func (c *circularBuffer) Reset() io.Reader {
+// Reset will reset the circular buffer.
+// The number of bytes to return can be specified.
+// If the number of bytes wanted is <= 0 the value will not be updated.
+func (c *circularBuffer) Reset(want int64) io.Reader {
+	if want > 0 {
+		c.want = want
+	}
 	c.read = 0
 	c.left = c.data
 	return c

--- a/pkg/generator/csv.go
+++ b/pkg/generator/csv.go
@@ -89,8 +89,8 @@ type CsvOpts struct {
 func csvOptsDefaults() CsvOpts {
 	return CsvOpts{
 		err:    nil,
-		cols:   500,
-		rows:   15,
+		cols:   15,
+		rows:   1000,
 		comma:  ',',
 		seed:   nil,
 		minLen: 5,
@@ -120,7 +120,7 @@ func newCsv(o Options) (Source, error) {
 	}
 	c.rng = rand.New(rndSrc)
 	c.obj.ContentType = "text/csv"
-	c.obj.Size = o.totalSize
+	c.obj.Size = 0
 	c.obj.setPrefix(o)
 
 	return &c, nil
@@ -129,6 +129,7 @@ func newCsv(o Options) (Source, error) {
 func (c *csvSource) Object() *Object {
 	opts := c.o.csv
 	var dst = c.buf.data[:0]
+	c.obj.Size = c.o.getSize(c.rng)
 	for i := 0; i < opts.rows; i++ {
 		for j := 0; j < opts.cols; j++ {
 			fieldLen := 1 + opts.minLen
@@ -145,7 +146,7 @@ func (c *csvSource) Object() *Object {
 		}
 	}
 	c.buf.data = dst
-	c.obj.Reader = c.buf.Reset()
+	c.obj.Reader = c.buf.Reset(0)
 	var nBuf [16]byte
 	randAsciiBytes(nBuf[:], c.rng)
 	c.obj.setName(string(nBuf[:]) + ".csv")


### PR DESCRIPTION
This makes it possible to use randomly sized files for upload.

Usage is pretty easy, just specify `-obj.randsize` and files will have a "random" size up to `-obj.size`. However, there are some things to consider "under the hood".

# Choosing file size

Naively choosing a random file size between 1 and `obj.size` will lead to a pretty uninteresting benchmark since 50% of all requests with be within `obj.size/2`  and `obj.size`. The segment below `obj.size/20` will have no real information since there is too little data.

So choosing a non-linear distribution seems reasonable. However, this leads to the need to define the base of the non-linear scale and the logarithm for distributing.

As a proposal, we use log2(x) to distribute objects and a maximum log2(x) - 8 as the base.

This means that objects will be distributed between (obj.size/256)  and obj.size in equal number for each doubling of the size. We could set the lower size to a fixed value, like 256 bytes, though that would of course dilute the higher values and spending a lot of time between benchmarking differences between 256 -> 512 bytes has little value.

This means that (obj.size/256) -> (obj.size/128) will have the same number of objects as `obj.size/2` -> `obj.size`.

Objects (horizontally) and their sizes: 

![objects (horizontally) and their sizes](https://user-images.githubusercontent.com/5663952/71828619-83381480-3057-11ea-9d6c-ff03607a66a7.png)

# Analysis

Printing out meaningful request analysis is kind of the same problem.

To keep the output meaningful and not overly verbose, the data is split into log(10) segments.

# Example:
```
λ warp analyze warp-get-2020-01-06[063948]-Q3Ch.csv.zst -requests
Operation: GET. Concurrency: 12. Hosts: 1.                                                 
                                                                         
Requests considered: 4361. Multiple sizes, average 17218609 bytes:                         
                                                                                           
Request size 100KB -> 1MB. Requests - 804:                                                 
 * Fastest: 995µs Slowest: 38.8965ms 50%: 14.9583ms 90%: 23.9356ms 99%: 33.9101ms          
 * First Byte: Average: 4.161847ms, Median: 2.9933ms, Best: 993.6µs, Worst: 25.9311ms      
                                                                                           
Request size 1MB -> 10MB. Requests - 1906:                                                 
 * Fastest: 997.6µs Slowest: 299.1976ms 50%: 48.8679ms 90%: 143.616ms 99%: 209.4404ms      
 * First Byte: Average: 4.591214ms, Median: 2.9933ms, Best: 0s, Worst: 124.6681ms          
                                                                                           
Request size 10MB -> 100MB. Requests - 1651:                                               
 * Fastest: 10.9691ms Slowest: 1.4301733s 50%: 300.1959ms 90%: 705.121ms 99%: 1.0970738s   
 * First Byte: Average: 3.88858ms, Median: 2.9933ms, Best: 990.8µs, Worst: 13.9605ms       
                                                                                           
Throughput:                                                                                
* Average: 1218.91 MB/s, 74.02 obj/s, 74.03 ops ended/s (59.046s)                          
                                                                                           
Aggregated Throughput, split into 59 x 1s time segments:                                   
 * Fastest: 1557.89 MB/s, 84.00 obj/s, 81.00 ops ended/s (1s)                              
 * 50% Median: 1240.01 MB/s, 70.86 obj/s, 70.00 ops ended/s (1s)                           
 * Slowest: 867.46 MB/s, 64.00 obj/s, 66.00 ops ended/s (1s)                                                                
```

We could of course match the log2 distribution of the files, but instead of 3 pretty clear, there would be 8 heavily distributed.

If a distribution has less than 5% of the total request count it is either merged into the next or discarded.