### PR TITLE
Automatic termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,38 @@ By default all benchmarks save all request details to a file named `warp-operati
 A custom file name can be specified using the `-benchdata` parameter.
 The raw data is [zstandard](https://facebook.github.io/zstd/) compressed CSV data.
 
+## automatic termination
+
+Adding `-autoterm` parameter will enable automatic termination when results are considered stable. 
+
+To detect a stable setup, warp continously downsample the current data to 25 data points stretched over the current timeframe.
+
+For a benchmark to be considered "stable", the last 7 of 25 data points must be within a specified percentage. 
+
+Looking at the throughput over time, it could look like this:
+
+![stable](https://user-images.githubusercontent.com/5663952/72053512-0df95900-327c-11ea-8bc5-9b4064fa595f.png)
+
+The red frame shows the window used to evaluate stability. 
+The height of the box is determined by the threshold percentage of the current speed.
+This percentage is user configurable through `-autoterm.pct`, default 7.5%. 
+The metric used for this is either MB/s or obj/s depending on the benchmark type.
+
+To make sure there is a good sample data, a minimum duration of the 7 of 25 samples is set. 
+This is configurable `-autoterm.dur`. 
+This specifies the minimum time length the benchmark must have been stable.
+
+If the benchmark doesn't autoterminate it will continue until the duration is reached.
+This cannot be used when benchmarks are running remotely.
+
+A permanent 'drift' in throughput will prevent automatic termination, 
+if the drift is more than the specified percentage.
+This is by design since this should be recorded.
+
+When using automatic termination be aware that you should not compare average speeds,
+since the length of the benchmark runs will likely be different. 
+Instead 50% medians are a much better metrics.
+
 ## multiple hosts
 
 Multiple hosts can be specified as comma-separated values, for instance `10.0.0.1:9000,10.0.0.2:9000` 

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -27,7 +27,7 @@ var (
 	deleteFlags = []cli.Flag{
 		cli.IntFlag{
 			Name:  "objects",
-			Value: 100000,
+			Value: 25000,
 			Usage: "Number of objects to upload.",
 		},
 		cli.StringFlag{

--- a/pkg/bench/analyze.go
+++ b/pkg/bench/analyze.go
@@ -219,6 +219,11 @@ func (s Segment) CSV(w *csv.Writer, idx int) error {
 }
 
 // String returns a string representation of the segment
+func (s Segment) Duration() time.Duration {
+	return s.EndsBefore.Sub(s.Start)
+}
+
+// String returns a string representation of the segment
 func (s Segment) String() string {
 	mb, ops, objs := s.SpeedPerSec()
 	speed := ""

--- a/pkg/bench/benchmark.go
+++ b/pkg/bench/benchmark.go
@@ -19,6 +19,7 @@ package bench
 import (
 	"context"
 	"math"
+	"time"
 
 	"github.com/minio/mc/pkg/console"
 	"github.com/minio/minio-go/v6"
@@ -52,9 +53,21 @@ type Common struct {
 	Clear           bool
 	PrepareProgress chan float64
 
+	// Auto termination is set when this is > 0.
+	AutoTermDur   time.Duration
+	AutoTermScale float64
+
 	// Default Put options.
 	PutOpts minio.PutObjectOptions
 }
+
+const (
+	// Split active ops into this many segments.
+	autoTermSamples = 25
+
+	// Number of segments that must be within limit.
+	autoTermCheck = 7
+)
 
 func (c *Common) GetCommon() *Common {
 	return c

--- a/pkg/bench/benchmark.go
+++ b/pkg/bench/benchmark.go
@@ -66,6 +66,7 @@ const (
 	autoTermSamples = 25
 
 	// Number of segments that must be within limit.
+	// The last segment will be the one considered 'current speed'.
 	autoTermCheck = 7
 )
 

--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -112,6 +112,10 @@ func (d *Delete) Start(ctx context.Context, start chan struct{}) Operations {
 	var wg sync.WaitGroup
 	wg.Add(d.Concurrency)
 	c := d.Collector
+	if d.AutoTermDur > 0 {
+		ctx = c.AutoTerm(ctx, "DELETE", d.AutoTermScale, autoTermCheck, autoTermSamples, d.AutoTermDur)
+	}
+
 	var mu sync.Mutex
 	for i := 0; i < d.Concurrency; i++ {
 		go func(i int) {

--- a/pkg/bench/get.go
+++ b/pkg/bench/get.go
@@ -128,6 +128,9 @@ func (g *Get) Start(ctx context.Context, start chan struct{}) Operations {
 	var wg sync.WaitGroup
 	wg.Add(g.Concurrency)
 	c := g.Collector
+	if g.AutoTermDur > 0 {
+		ctx = c.AutoTerm(ctx, "GET", g.AutoTermScale, autoTermCheck, autoTermSamples, g.AutoTermDur)
+	}
 	for i := 0; i < g.Concurrency; i++ {
 		go func(i int) {
 			rng := rand.New(rand.NewSource(int64(i)))

--- a/pkg/bench/list.go
+++ b/pkg/bench/list.go
@@ -123,6 +123,10 @@ func (d *List) Start(ctx context.Context, start chan struct{}) Operations {
 	var wg sync.WaitGroup
 	wg.Add(d.Concurrency)
 	c := d.Collector
+	if d.AutoTermDur > 0 {
+		ctx = c.AutoTerm(ctx, "LIST", d.AutoTermScale, autoTermCheck, autoTermSamples, d.AutoTermDur)
+	}
+
 	for i := 0; i < d.Concurrency; i++ {
 		go func(i int) {
 			rcv := c.Receiver()

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -72,7 +72,7 @@ func NewCollector() *Collector {
 	return r
 }
 
-// AutoTerm will check if throughout is within 'threshold' (0 -> ) for wantSamples,
+// AutoTerm will check if throughput is within 'threshold' (0 -> ) for wantSamples,
 // when the current operations are split into 'splitInto' segments.
 // The minimum duration for the calculation can be set as well.
 // Segment splitting may cause less than this duration to be used.

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -116,7 +116,7 @@ func (c *Collector) AutoTerm(ctx context.Context, op string, threshold float64, 
 			}
 			// Use last segment as our base.
 			mb, _, objs := segs[len(segs)-1].SpeedPerSec()
-			// Only use the
+			// Only use the segments we are interested in.
 			segs = segs[len(segs)-wantSamples : len(segs)-1]
 			for _, seg := range segs {
 				segMB, _, segObjs := seg.SpeedPerSec()
@@ -130,14 +130,15 @@ func (c *Collector) AutoTerm(ctx context.Context, op string, threshold float64, 
 					continue checkloop
 				}
 			}
+			// All checks passed.
 			if mb > 0 {
-				console.Printf("\rThroughput %0.01fMB/s within %d%% for %v. Assuming stability. Terminating benchmark.\n",
-					mb, int(threshold*100),
-					segs[0].Duration().Round(time.Millisecond)*time.Duration(len(segs)))
+				console.Printf("\rThroughput %0.01fMB/s within %f%% for %v. Assuming stability. Terminating benchmark.\n",
+					mb, threshold*100,
+					segs[0].Duration().Round(time.Millisecond)*time.Duration(len(segs)+1))
 			} else {
-				console.Printf("\rThroughput %0.01f objects/s within %d%% for %v. Assuming stability. Terminating benchmark.\n",
-					objs, int(threshold*100),
-					segs[0].Duration().Round(time.Millisecond)*time.Duration(len(segs)))
+				console.Printf("\rThroughput %0.01f objects/s within %f%% for %v. Assuming stability. Terminating benchmark.\n",
+					objs, threshold*100,
+					segs[0].Duration().Round(time.Millisecond)*time.Duration(len(segs)+1))
 			}
 			return
 		}

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -41,6 +41,10 @@ func (u *Put) Start(ctx context.Context, start chan struct{}) Operations {
 	var wg sync.WaitGroup
 	wg.Add(u.Concurrency)
 	c := NewCollector()
+	if u.AutoTermDur > 0 {
+		ctx = c.AutoTerm(ctx, "PUT", u.AutoTermScale, autoTermCheck, autoTermSamples, u.AutoTermDur)
+	}
+
 	for i := 0; i < u.Concurrency; i++ {
 		go func(i int) {
 			rcv := c.Receiver()


### PR DESCRIPTION
This adds automatic termination when results are considered "stable". This is enabled by using `-autoterm` parameter.

Looking at a throughput graph there can be pretty big variance:

Example of PUT run, each datapoint 1 second:

![image](https://user-images.githubusercontent.com/5663952/71907331-a7abf380-3120-11ea-8a59-a0ad3a604b30.png)

To easier be able to judge this, we continously downsample the current data to 25 data points stretched over the currently known data.

Same data, but with each datapoint 5 seconds long (22 datapoints):
![image](https://user-images.githubusercontent.com/5663952/71907370-ba262d00-3120-11ea-8d0c-a772edee04d1.png)

For a benchmark to be considered "stable", the last 7 of 25 data points must be within a specified percentage. This percentage is user configurable through `-autoterm.pct`, default 7.5%. The metric used for this is either MB/s or obj/s depending on the benchmark type.

To make sure there is a good sample data, a minimum duration of the 7 of 25 samples is set. This is configurable `-autoterm.dur`. This effectively specifies the minimum time length the benchmark must have been stable.

If the benchmark doesn't autoterminate it will continue until the duration is reached.

This cannot be used when benchmarks are running remotely via #12 - but could eventually be expanded to that.

A permanent 'drift' in the numbers will prevent automatic termination. This is by design since this should be recorded.