### PR TITLE
Add StatObject Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,28 @@ Aggregated, split into 59 x 1s time segments:
 * Slowest: 27917.33 obj/s, 35.00 ops ended/s (1s)
 ```
 
+## stat
+
+Benchmarking [stat object](https://docs.min.io/docs/golang-client-api-reference#StatObject) operations will upload `-objects` objects of size `-obj.size` with `-concurrent` prefixes.
+
+The main benchmark will do individual requests to get object information for the uploaded objects.
+
+Since the object size is of little importance, only objects per second is reported.
+
+Example: 
+```
+$ warp stat -autoterm
+[...]
+-------------------
+Operation: STAT. Concurrency: 12. Hosts: 1.
+* Average: 9536.72 obj/s (36.592s, starting 04:46:38 PST)
+
+Aggregated Throughput, split into 36 x 1s time segments:
+ * Fastest: 10259.67 obj/s (1s, starting 04:46:38 PST)
+ * 50% Median: 9585.33 obj/s (1s, starting 04:47:05 PST)
+ * Slowest: 8897.26 obj/s (1s, starting 04:47:06 PST)
+```
+
 # distributed benchmarking
 
 It is possible to coordinate several warp instances automatically.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -88,6 +88,7 @@ func init() {
 		putCmd,
 		deleteCmd,
 		listCmd,
+		statCmd,
 	}
 	b := []cli.Command{
 		analyzeCmd,

--- a/cli/get.go
+++ b/cli/get.go
@@ -62,6 +62,7 @@ EXAMPLES:
 func mainGet(ctx *cli.Context) error {
 	checkGetSyntax(ctx)
 	src := newGenSource(ctx)
+	sse := newSSE(ctx)
 	b := bench.Get{
 		Common: bench.Common{
 			Client:      newClient(ctx),
@@ -70,11 +71,11 @@ func mainGet(ctx *cli.Context) error {
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
 			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: newSSE(ctx),
+				ServerSideEncryption: sse,
 			},
 		},
 		CreateObjects: ctx.Int("objects"),
-		GetOpts:       minio.GetObjectOptions{ServerSideEncryption: newSSE(ctx)},
+		GetOpts:       minio.GetObjectOptions{ServerSideEncryption: sse},
 	}
 	return runBench(ctx, &b)
 }

--- a/cli/stat.go
+++ b/cli/stat.go
@@ -39,7 +39,7 @@ var (
 
 var statCmd = cli.Command{
 	Name:   "stat",
-	Usage:  "benchmark stat objects",
+	Usage:  "benchmark stat objects (get fil einfo)",
 	Action: mainStat,
 	Before: setGlobalsFromContext,
 	Flags:  combineFlags(globalFlags, ioFlags, statFlags, genFlags, benchFlags, analyzeFlags),
@@ -62,6 +62,7 @@ EXAMPLES:
 func mainStat(ctx *cli.Context) error {
 	checkStatSyntax(ctx)
 	src := newGenSource(ctx)
+	sse := newSSE(ctx)
 
 	b := bench.Stat{
 		Common: bench.Common{
@@ -71,10 +72,13 @@ func mainStat(ctx *cli.Context) error {
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
 			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: newSSE(ctx),
+				ServerSideEncryption: sse,
 			},
 		},
 		CreateObjects: ctx.Int("objects"),
+		StatOpts: minio.StatObjectOptions{
+			GetObjectOptions: minio.GetObjectOptions{ServerSideEncryption: sse},
+		},
 	}
 	return runBench(ctx, &b)
 }

--- a/cli/stat.go
+++ b/cli/stat.go
@@ -1,0 +1,85 @@
+/*
+ * Warp (C) 2019-2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"github.com/minio/cli"
+	"github.com/minio/minio-go/v6"
+	"github.com/minio/warp/pkg/bench"
+)
+
+var (
+	statFlags = []cli.Flag{
+		cli.IntFlag{
+			Name:  "objects",
+			Value: 10000,
+			Usage: "Number of objects to upload. Rounded to have equal concurrent objects.",
+		},
+		cli.StringFlag{
+			Name:  "obj.size",
+			Value: "1KB",
+			Usage: "Size of each generated object. Can be a number or 10KB/MB/GB. All sizes are base 2 binary.",
+		},
+	}
+)
+
+var statCmd = cli.Command{
+	Name:   "stat",
+	Usage:  "benchmark stat objects",
+	Action: mainStat,
+	Before: setGlobalsFromContext,
+	Flags:  combineFlags(globalFlags, ioFlags, statFlags, genFlags, benchFlags, analyzeFlags),
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} [FLAGS]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+
+EXAMPLES:
+...
+ `,
+}
+
+// mainDelete is the entry point for get command.
+func mainStat(ctx *cli.Context) error {
+	checkStatSyntax(ctx)
+	src := newGenSource(ctx)
+
+	b := bench.Stat{
+		Common: bench.Common{
+			Client:      newClient(ctx),
+			Concurrency: ctx.Int("concurrent"),
+			Source:      src,
+			Bucket:      ctx.String("bucket"),
+			Location:    "",
+			PutOpts: minio.PutObjectOptions{
+				ServerSideEncryption: newSSE(ctx),
+			},
+		},
+		CreateObjects: ctx.Int("objects"),
+	}
+	return runBench(ctx, &b)
+}
+
+func checkStatSyntax(ctx *cli.Context) {
+	checkAnalyze(ctx)
+	checkBenchmark(ctx)
+}

--- a/pkg/bench/stat.go
+++ b/pkg/bench/stat.go
@@ -157,7 +157,7 @@ func (g *Stat) Start(ctx context.Context, wait chan struct{}) (Operations, error
 				var err error
 				objI, err := client.StatObject(g.Bucket, obj.Name, opts)
 				if err != nil {
-					console.Errorln("download error:", err)
+					console.Errorln("StatObject error:", err)
 					op.Err = err.Error()
 					op.End = time.Now()
 					rcv <- op
@@ -166,7 +166,7 @@ func (g *Stat) Start(ctx context.Context, wait chan struct{}) (Operations, error
 				}
 				op.End = time.Now()
 				if objI.Size != obj.Size && op.Err == "" {
-					op.Err = fmt.Sprint("unexpected download size. want:", obj.Size, ", got:", objI.Size)
+					op.Err = fmt.Sprint("unexpected file size. want:", obj.Size, ", got:", objI.Size)
 					console.Errorln(op.Err)
 				}
 				rcv <- op

--- a/pkg/bench/stat.go
+++ b/pkg/bench/stat.go
@@ -19,8 +19,6 @@ package bench
 import (
 	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"math/rand"
 	"sync"
 	"time"
@@ -30,20 +28,20 @@ import (
 	"github.com/minio/warp/pkg/generator"
 )
 
-// Get benchmarks download speed.
-type Get struct {
+// Stat benchmarks download speed.
+type Stat struct {
 	CreateObjects int
 	Collector     *Collector
 	objects       []generator.Object
 
-	// Default Get options.
-	GetOpts minio.GetObjectOptions
+	// Default Stat options.
+	StatOpts minio.StatObjectOptions
 	Common
 }
 
 // Prepare will create an empty bucket or delete any content already there
 // and upload a number of objects.
-func (g *Get) Prepare(ctx context.Context) error {
+func (g *Stat) Prepare(ctx context.Context) error {
 	if err := g.createEmptyBucket(ctx); err != nil {
 		return err
 	}
@@ -121,39 +119,21 @@ func (g *Get) Prepare(ctx context.Context) error {
 	return groupErr
 }
 
-type firstByteRecorder struct {
-	t *time.Time
-	r io.Reader
-}
-
-func (f *firstByteRecorder) Read(p []byte) (n int, err error) {
-	if f.t != nil || len(p) == 0 {
-		return f.r.Read(p)
-	}
-	// Read a single byte.
-	n, err = f.r.Read(p[:1])
-	if n > 0 {
-		t := time.Now()
-		f.t = &t
-	}
-	return n, err
-}
-
 // Start will execute the main benchmark.
 // Operations should begin executing when the start channel is closed.
-func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error) {
+func (g *Stat) Start(ctx context.Context, wait chan struct{}) (Operations, error) {
 	var wg sync.WaitGroup
 	wg.Add(g.Concurrency)
 	c := g.Collector
 	if g.AutoTermDur > 0 {
-		ctx = c.AutoTerm(ctx, "GET", g.AutoTermScale, autoTermCheck, autoTermSamples, g.AutoTermDur)
+		ctx = c.AutoTerm(ctx, "STAT", g.AutoTermScale, autoTermCheck, autoTermSamples, g.AutoTermDur)
 	}
 	for i := 0; i < g.Concurrency; i++ {
 		go func(i int) {
 			rng := rand.New(rand.NewSource(int64(i)))
 			rcv := c.Receiver()
 			defer wg.Done()
-			opts := g.GetOpts
+			opts := g.StatOpts
 			done := ctx.Done()
 
 			<-wait
@@ -163,20 +143,19 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 					return
 				default:
 				}
-				fbr := firstByteRecorder{}
 				obj := g.objects[rng.Intn(len(g.objects))]
 				client, cldone := g.Client()
 				op := Operation{
-					OpType:   "GET",
+					OpType:   "STAT",
 					Thread:   uint16(i),
-					Size:     obj.Size,
+					Size:     0,
 					File:     obj.Name,
 					ObjPerOp: 1,
 					Endpoint: client.EndpointURL().String(),
 				}
 				op.Start = time.Now()
 				var err error
-				fbr.r, err = client.GetObject(g.Bucket, obj.Name, opts)
+				objI, err := client.StatObject(g.Bucket, obj.Name, opts)
 				if err != nil {
 					console.Errorln("download error:", err)
 					op.Err = err.Error()
@@ -185,15 +164,9 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 					cldone()
 					continue
 				}
-				n, err := io.Copy(ioutil.Discard, &fbr)
-				if err != nil {
-					console.Errorln("download error:", err)
-					op.Err = err.Error()
-				}
-				op.FirstByte = fbr.t
 				op.End = time.Now()
-				if n != obj.Size && op.Err == "" {
-					op.Err = fmt.Sprint("unexpected download size. want:", obj.Size, ", got:", n)
+				if objI.Size != obj.Size && op.Err == "" {
+					op.Err = fmt.Sprint("unexpected download size. want:", obj.Size, ", got:", objI.Size)
 					console.Errorln(op.Err)
 				}
 				rcv <- op
@@ -206,6 +179,6 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 }
 
 // Cleanup deletes everything uploaded to the bucket.
-func (g *Get) Cleanup(ctx context.Context) {
+func (g *Stat) Cleanup(ctx context.Context) {
 	g.deleteAllInBucket(ctx)
 }


### PR DESCRIPTION
Benchmarking [stat object](https://docs.min.io/docs/golang-client-api-reference#StatObject) operations will upload `-objects` objects of size `-obj.size` with `-concurrent` prefixes.

The main benchmark will do individual requests to get object information for the uploaded objects.

Since the object size is of little importance, only objects per second is reported.

Example:
```
$ warp stat -autoterm
[...]
-------------------
Operation: STAT. Concurrency: 12. Hosts: 1.
* Average: 9536.72 obj/s (36.592s, starting 04:46:38 PST)

Aggregated Throughput, split into 36 x 1s time segments:
 * Fastest: 10259.67 obj/s (1s, starting 04:46:38 PST)
 * 50% Median: 9585.33 obj/s (1s, starting 04:47:05 PST)
 * Slowest: 8897.26 obj/s (1s, starting 04:47:06 PST)
```