### PR TITLE
Add mixed type benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ It is possible to get request statistics by adding the `-requests` parameter:
 Mixed operations.
 
 Operation: GET
- * 705.96 MB/s, 70.60 obj/s (59.976s, starting 06:54:08 PST) (45.0% of operations)
+ * 725.42 MB/s, 72.54 obj/s (59.961s, starting 07:07:34 PST) (45.0% of operations)
 
-Requests considered: 4175:
- * 50%: 117.6865ms 90%: 296.2074ms 99%: 546.5379ms Fastest: 7.9655ms Slowest: 739.3079ms
- * First Byte: Average: 7.408536ms, Median: 3.9905ms, Best: 0s, Worst: 169.5449ms
+Requests considered: 4304:
+ * Avg: 131ms 50%: 124ms 90%: 300ms 99%: 495ms Fastest: 7ms Slowest: 700ms
+ * First Byte: Average: 6ms, Median: 3ms, Best: 0s, Worst: 185ms
 
 [...]
 ```

--- a/README.md
+++ b/README.md
@@ -144,6 +144,55 @@ from the clients for total result.
 When benchmarks are done per host averages will be printed out.
 For further details, the `-analyze.hostdetails` parameter can also be used.
 
+## mixed
+
+Mixed mode benchmark will test several operation types at once. 
+The benchmark will upload `-objects` objects of size `-obj.size` 
+and use these objects as a pool for the benchmark.
+As new objects are uploaded/deleted they are added/removed from the pool.
+
+The distribution of operations can be adjusted with the `-get-distrib`, `-stat-distrib`,
+`-put-distrib` and `-delete-distrib` parameters. 
+The final distribution will be determined by the fraction of each value of the total.
+Note that `put-distrib` must be bigger or equal to `-delete-distrib` to not eventually run out of objects. 
+To disable a type, set its distribution to 0.  
+
+Example:
+```
+λ warp mixed -duration=1m
+[...]
+Mixed operations.
+
+Operation: GET
+ * 632.28 MB/s, 354.78 obj/s (59.993s, starting 07:44:05 PST) (45.0% of operations)
+
+Operation: STAT
+ * 236.38 obj/s (59.966s, starting 07:44:05 PST) (30.0% of operations)
+
+Operation: PUT
+ * 206.11 MB/s, 118.23 obj/s (59.994s, starting 07:44:05 PST) (15.0% of operations)
+
+Operation: DELETE
+ * 78.91 obj/s (59.927s, starting 07:44:05 PST) (10.0% of operations)
+```
+
+It is possible to get request statistics by adding the `-requests` parameter: 
+```
+λ warp mixed -duration=1m -requests
+Mixed operations.
+
+Operation: GET
+ * 705.96 MB/s, 70.60 obj/s (59.976s, starting 06:54:08 PST) (45.0% of operations)
+
+Requests considered: 4175:
+ * 50%: 117.6865ms 90%: 296.2074ms 99%: 546.5379ms Fastest: 7.9655ms Slowest: 739.3079ms
+ * First Byte: Average: 7.408536ms, Median: 3.9905ms, Best: 0s, Worst: 169.5449ms
+
+[...]
+```
+
+If multiple hosts were used statistics for each host will also be displayed.
+ 
 ## get
 
 Benchmarking get operations will upload `-objects` objects of size `-obj.size` and attempt to

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -375,12 +375,14 @@ func printRequestAnalysis(ctx *cli.Context, ops bench.Operations) {
 		}
 
 		active.SortByDuration()
+
 		console.Println(
-			" * 50%:", active.Median(0.5).Duration(),
-			"90%:", active.Median(0.9).Duration(),
-			"99%:", active.Median(0.99).Duration(),
-			"Fastest:", active.Median(0).Duration(),
-			"Slowest:", active.Median(1).Duration(),
+			" * Avg:", active.AvgDuration().Round(time.Millisecond),
+			"50%:", active.Median(0.5).Duration().Round(time.Millisecond),
+			"90%:", active.Median(0.9).Duration().Round(time.Millisecond),
+			"99%:", active.Median(0.99).Duration().Round(time.Millisecond),
+			"Fastest:", active.Median(0).Duration().Round(time.Millisecond),
+			"Slowest:", active.Median(1).Duration().Round(time.Millisecond),
 		)
 
 		ttfb := active.TTFB(start, end)
@@ -431,10 +433,11 @@ func printRequestAnalysis(ctx *cli.Context, ops bench.Operations) {
 			filtered.SortByDuration()
 			console.SetColor("Print", color.New(color.FgWhite))
 			console.Println(" *", ep, "-", len(filtered), "requests:",
-				"\n\t- Fastest:", filtered.Median(0).Duration(),
-				"Slowest:", filtered.Median(1).Duration(),
-				"50%:", filtered.Median(0.5).Duration(),
-				"90%:", filtered.Median(0.9).Duration())
+				"\n\t- Avg:", filtered.AvgDuration().Round(time.Millisecond),
+				"Fastest:", filtered.Median(0).Duration().Round(time.Millisecond),
+				"Slowest:", filtered.Median(1).Duration().Round(time.Millisecond),
+				"50%:", filtered.Median(0.5).Duration().Round(time.Millisecond),
+				"90%:", filtered.Median(0.9).Duration().Round(time.Millisecond))
 			ttfb := filtered.TTFB(filtered.TimeRange())
 			if ttfb.Average > 0 {
 				console.Println("\t- First Byte:", ttfb)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -84,6 +84,7 @@ func Main(args []string) {
 }
 func init() {
 	a := []cli.Command{
+		mixedCmd,
 		getCmd,
 		putCmd,
 		deleteCmd,

--- a/cli/mixed.go
+++ b/cli/mixed.go
@@ -112,7 +112,7 @@ func mainMixed(ctx *cli.Context) error {
 				ServerSideEncryption: sse,
 			},
 		},
-		Dist: dist,
+		Dist: &dist,
 	}
 	return runBench(ctx, &b)
 }

--- a/cli/mixed.go
+++ b/cli/mixed.go
@@ -1,0 +1,123 @@
+/*
+ * Warp (C) 2019-2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"github.com/minio/cli"
+	"github.com/minio/mc/pkg/probe"
+	"github.com/minio/minio-go/v6"
+	"github.com/minio/warp/pkg/bench"
+)
+
+var (
+	mixedFlags = []cli.Flag{
+		cli.IntFlag{
+			Name:  "objects",
+			Value: 2500,
+			Usage: "Number of objects to upload.",
+		},
+		cli.StringFlag{
+			Name:  "obj.size",
+			Value: "10MB",
+			Usage: "Size of each generated object. Can be a number or 10KB/MB/GB. All sizes are base 2 binary.",
+		},
+		cli.Float64Flag{
+			Name:  "get-distrib",
+			Usage: "The amount of GET operations.",
+			Value: 45,
+		},
+		cli.Float64Flag{
+			Name:  "stat-distrib",
+			Usage: "The amount of STAT operations.",
+			Value: 30,
+		},
+		cli.Float64Flag{
+			Name:  "put-distrib",
+			Usage: "The amount of PUT operations.",
+			Value: 15,
+		},
+		cli.Float64Flag{
+			Name:  "delete-distrib",
+			Usage: "The amount of DELETE operations. Must be at least the same as PUT.",
+			Value: 10,
+		},
+	}
+)
+
+var mixedCmd = cli.Command{
+	Name:   "mixed",
+	Usage:  "benchmark mixed objects",
+	Action: mainMixed,
+	Before: setGlobalsFromContext,
+	Flags:  combineFlags(globalFlags, ioFlags, mixedFlags, genFlags, benchFlags, analyzeFlags),
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} [FLAGS]
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}
+
+EXAMPLES:
+...
+ `,
+}
+
+// mainMixed is the entry point for mixed command.
+func mainMixed(ctx *cli.Context) error {
+	checkMixedSyntax(ctx)
+	src := newGenSource(ctx)
+	sse := newSSE(ctx)
+	dist := bench.MixedDistribution{
+		Distribution: map[string]float64{
+			"GET":    ctx.Float64("get-distrib"),
+			"STAT":   ctx.Float64("stat-distrib"),
+			"PUT":    ctx.Float64("put-distrib"),
+			"DELETE": ctx.Float64("delete-distrib"),
+		},
+	}
+	err := dist.Generate(ctx.Int("objects") * 2)
+	fatalIf(probe.NewError(err), "Invalid distribution")
+	b := bench.Mixed{
+		Common: bench.Common{
+			Client:      newClient(ctx),
+			Concurrency: ctx.Int("concurrent"),
+			Source:      src,
+			Bucket:      ctx.String("bucket"),
+			Location:    "",
+			PutOpts: minio.PutObjectOptions{
+				ServerSideEncryption: sse,
+			},
+		},
+		CreateObjects: ctx.Int("objects"),
+		GetOpts:       minio.GetObjectOptions{ServerSideEncryption: sse},
+		StatOpts: minio.StatObjectOptions{
+			GetObjectOptions: minio.GetObjectOptions{
+				ServerSideEncryption: sse,
+			},
+		},
+		Dist: dist,
+	}
+	return runBench(ctx, &b)
+}
+
+func checkMixedSyntax(ctx *cli.Context) {
+	checkAnalyze(ctx)
+	checkBenchmark(ctx)
+}

--- a/pkg/bench/analyze.go
+++ b/pkg/bench/analyze.go
@@ -322,5 +322,6 @@ func (t TTFB) String() string {
 	if t.Average == 0 {
 		return ""
 	}
-	return fmt.Sprintf("Average: %v, Median: %v, Best: %v, Worst: %v", t.Average, t.Median, t.Best, t.Worst)
+	return fmt.Sprintf("Average: %v, Median: %v, Best: %v, Worst: %v",
+		t.Average.Round(time.Millisecond), t.Median.Round(time.Millisecond), t.Best.Round(time.Millisecond), t.Worst.Round(time.Millisecond))
 }

--- a/pkg/bench/analyze.go
+++ b/pkg/bench/analyze.go
@@ -30,6 +30,7 @@ type SegmentOptions struct {
 	From           time.Time
 	PerSegDuration time.Duration
 	AllThreads     bool
+	MultiOp        bool
 }
 
 // A Segment represents totals of operations in a specific time segment
@@ -69,6 +70,7 @@ func (o Operations) Total(allThreads bool) Segment {
 		From:           start,
 		PerSegDuration: end.Sub(start) - 1,
 		AllThreads:     allThreads,
+		MultiOp:        o.IsMultiOp(),
 	})[0]
 }
 
@@ -146,6 +148,10 @@ func (o Operations) Segment(so SegmentOptions) Segments {
 			Objects:    0,
 			Start:      segStart,
 			EndsBefore: segStart.Add(so.PerSegDuration),
+		}
+		if so.MultiOp {
+			s.OpType = ""
+			s.ObjsPerOp = 0
 		}
 		for _, op := range o {
 			op.Aggregate(&s)

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -36,7 +36,7 @@ import (
 type Mixed struct {
 	CreateObjects int
 	Collector     *Collector
-	Dist          MixedDistribution
+	Dist          *MixedDistribution
 
 	GetOpts  minio.GetObjectOptions
 	StatOpts minio.StatObjectOptions

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -1,0 +1,353 @@
+/*
+ * Warp (C) 2019-2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/minio/mc/pkg/console"
+	"github.com/minio/minio-go/v6"
+	"github.com/minio/warp/pkg/generator"
+)
+
+// Mixed benchmarks download speed.
+type Mixed struct {
+	CreateObjects int
+	Collector     *Collector
+	Dist          MixedDistribution
+
+	GetOpts  minio.GetObjectOptions
+	StatOpts minio.StatObjectOptions
+	Common
+}
+
+type MixedDistribution struct {
+	// Operation -> distribution.
+	Distribution map[string]float64
+	ops          []string
+	objects      map[string]generator.Object
+	rng          *rand.Rand
+
+	current int
+	mu      sync.Mutex
+}
+
+func (m *MixedDistribution) Generate(allocObjs int) error {
+	if m.Distribution["DELETE"] > m.Distribution["PUT"] {
+		return errors.New("DELETE distribution cannot be bigger than PUT")
+	}
+	m.objects = make(map[string]generator.Object, allocObjs)
+
+	err := m.normalize()
+	if err != nil {
+		return err
+	}
+
+	const genOps = 1000
+	m.ops = make([]string, 0, genOps)
+	for op, dist := range m.Distribution {
+		add := int(0.5 + dist*genOps)
+		for i := 0; i < add; i++ {
+			m.ops = append(m.ops, op)
+		}
+	}
+	m.rng = rand.New(rand.NewSource(0xabad1dea))
+	sort.Slice(m.ops, func(i, j int) bool {
+		return m.rng.Int63()&1 == 0
+	})
+	return nil
+}
+
+func (m *MixedDistribution) normalize() error {
+	total := 0.0
+	for op, dist := range m.Distribution {
+		if dist < 0 {
+			return fmt.Errorf("negative distribution requested for op %q", op)
+		}
+		total += dist
+	}
+	if total == 0 {
+		return fmt.Errorf("no distribution set, total is 0")
+	}
+	for op, dist := range m.Distribution {
+		m.Distribution[op] = dist / total
+	}
+	return nil
+}
+
+func (m *MixedDistribution) randomObj() generator.Object {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Use map randomness to select.
+	for _, o := range m.objects {
+		return o
+	}
+	panic("ran out of objects")
+}
+
+func (m *MixedDistribution) deleteRandomObj() generator.Object {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Use map randomness to select.
+	for k, o := range m.objects {
+		delete(m.objects, k)
+		return o
+	}
+	panic("ran out of objects")
+}
+
+func (m *MixedDistribution) addObj(o generator.Object) {
+	m.mu.Lock()
+	m.objects[o.Name] = o
+	m.mu.Unlock()
+}
+
+func (m *MixedDistribution) getOp() string {
+	m.mu.Lock()
+	op := m.ops[m.current]
+	m.current = (m.current + 1) % len(m.ops)
+	m.mu.Unlock()
+	return op
+}
+
+// Prepare will create an empty bucket or delete any content already there
+// and upload a number of objects.
+func (g *Mixed) Prepare(ctx context.Context) error {
+	if err := g.createEmptyBucket(ctx); err != nil {
+		return err
+	}
+	src := g.Source()
+	console.Infoln("Uploading", g.CreateObjects, "Objects of", src.String())
+	var wg sync.WaitGroup
+	wg.Add(g.Concurrency)
+	g.Collector = NewCollector()
+	obj := make(chan struct{}, g.CreateObjects)
+	for i := 0; i < g.CreateObjects; i++ {
+		obj <- struct{}{}
+	}
+	close(obj)
+	var groupErr error
+	var mu sync.Mutex
+	for i := 0; i < g.Concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			src := g.Source()
+			for range obj {
+				opts := g.PutOpts
+				done := ctx.Done()
+
+				select {
+				case <-done:
+					return
+				default:
+				}
+				obj := src.Object()
+				client, cldone := g.Client()
+				opts.ContentType = obj.ContentType
+				n, err := client.PutObject(g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				if err != nil {
+					err := fmt.Errorf("upload error: %w", err)
+					console.Error(err)
+					mu.Lock()
+					if groupErr == nil {
+						groupErr = err
+					}
+					mu.Unlock()
+					return
+				}
+				if n != obj.Size {
+					err := fmt.Errorf("short upload. want: %d, got %d", obj.Size, n)
+					console.Error(err)
+					mu.Lock()
+					if groupErr == nil {
+						groupErr = err
+					}
+					mu.Unlock()
+					return
+				}
+				cldone()
+				obj.Reader = nil
+				g.Dist.addObj(*obj)
+				g.prepareProgress(float64(len(g.Dist.objects)) / float64(g.CreateObjects))
+			}
+		}(i)
+	}
+	wg.Wait()
+	return groupErr
+}
+
+// Start will execute the main benchmark.
+// Operations should begin executing when the start channel is closed.
+func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, error) {
+	var wg sync.WaitGroup
+	wg.Add(g.Concurrency)
+	c := g.Collector
+	if g.AutoTermDur > 0 {
+		ctx = c.AutoTerm(ctx, "MIXED", g.AutoTermScale, autoTermCheck, autoTermSamples, g.AutoTermDur)
+	}
+	for i := 0; i < g.Concurrency; i++ {
+		go func(i int) {
+			rcv := c.Receiver()
+			defer wg.Done()
+			done := ctx.Done()
+			src := g.Source()
+			putOpts := g.PutOpts
+			statOpts := g.StatOpts
+
+			<-wait
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				operation := g.Dist.getOp()
+				switch operation {
+				case "GET":
+					fbr := firstByteRecorder{}
+					obj := g.Dist.randomObj()
+					client, cldone := g.Client()
+					op := Operation{
+						OpType:   operation,
+						Thread:   uint16(i),
+						Size:     obj.Size,
+						File:     obj.Name,
+						ObjPerOp: 1,
+						Endpoint: client.EndpointURL().String(),
+					}
+					op.Start = time.Now()
+					var err error
+					fbr.r, err = client.GetObject(g.Bucket, obj.Name, g.GetOpts)
+					if err != nil {
+						console.Errorln("download error:", err)
+						op.Err = err.Error()
+						op.End = time.Now()
+						rcv <- op
+						cldone()
+						continue
+					}
+					n, err := io.Copy(ioutil.Discard, &fbr)
+					if err != nil {
+						console.Errorln("download error:", err)
+						op.Err = err.Error()
+					}
+					op.FirstByte = fbr.t
+					op.End = time.Now()
+					if n != obj.Size && op.Err == "" {
+						op.Err = fmt.Sprint("unexpected download size. want:", obj.Size, ", got:", n)
+						console.Errorln(op.Err)
+					}
+					rcv <- op
+					cldone()
+				case "PUT":
+					obj := src.Object()
+					putOpts.ContentType = obj.ContentType
+					client, cldone := g.Client()
+					op := Operation{
+						OpType:   operation,
+						Thread:   uint16(i),
+						Size:     obj.Size,
+						File:     obj.Name,
+						ObjPerOp: 1,
+						Endpoint: client.EndpointURL().String(),
+					}
+					op.Start = time.Now()
+					n, err := client.PutObject(g.Bucket, obj.Name, obj.Reader, obj.Size, putOpts)
+					op.End = time.Now()
+					if err != nil {
+						console.Errorln("upload error:", err)
+						op.Err = err.Error()
+					}
+					if n != obj.Size {
+						err := fmt.Sprint("short upload. want:", obj.Size, ", got:", n)
+						if op.Err == "" {
+							op.Err = err
+						}
+						console.Errorln(err)
+					}
+					cldone()
+					if op.Err == "" {
+						g.Dist.addObj(*obj)
+					}
+					rcv <- op
+				case "DELETE":
+					client, cldone := g.Client()
+					obj := g.Dist.deleteRandomObj()
+					op := Operation{
+						OpType:   operation,
+						Thread:   uint16(i),
+						Size:     0,
+						File:     obj.Name,
+						ObjPerOp: 1,
+						Endpoint: client.EndpointURL().String(),
+					}
+					op.Start = time.Now()
+					err := client.RemoveObject(g.Bucket, obj.Name)
+					op.End = time.Now()
+					cldone()
+					if err != nil {
+						console.Errorln("delete error:", err)
+						op.Err = err.Error()
+					}
+					rcv <- op
+				case "STAT":
+					obj := g.Dist.randomObj()
+					client, cldone := g.Client()
+					op := Operation{
+						OpType:   operation,
+						Thread:   uint16(i),
+						Size:     0,
+						File:     obj.Name,
+						ObjPerOp: 1,
+						Endpoint: client.EndpointURL().String(),
+					}
+					op.Start = time.Now()
+					var err error
+					objI, err := client.StatObject(g.Bucket, obj.Name, statOpts)
+					if err != nil {
+						console.Errorln("stat error:", err)
+						op.Err = err.Error()
+					}
+					op.End = time.Now()
+					if objI.Size != obj.Size && op.Err == "" {
+						op.Err = fmt.Sprint("unexpected stat size. want:", obj.Size, ", got:", objI.Size)
+						console.Errorln(op.Err)
+					}
+					rcv <- op
+					cldone()
+				default:
+					console.Errorln("unknown operation:", operation)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	return c.Close(), nil
+}
+
+// Cleanup deletes everything uploaded to the bucket.
+func (g *Mixed) Cleanup(ctx context.Context) {
+	g.deleteAllInBucket(ctx)
+}

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -205,7 +205,7 @@ func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 	wg.Add(g.Concurrency)
 	c := g.Collector
 	if g.AutoTermDur > 0 {
-		ctx = c.AutoTerm(ctx, "MIXED", g.AutoTermScale, autoTermCheck, autoTermSamples, g.AutoTermDur)
+		ctx = c.AutoTerm(ctx, "", g.AutoTermScale, autoTermCheck, autoTermSamples, g.AutoTermDur)
 	}
 	for i := 0; i < g.Concurrency; i++ {
 		go func(i int) {

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -408,6 +408,32 @@ func (o Operations) OpTypes() []string {
 	return dst
 }
 
+// IsMultiOp returns true if different operation types are overlapping.
+func (o Operations) IsMultiOp() bool {
+	types := o.OpTypes()
+	if len(types) <= 1 {
+		return false
+	}
+	for _, a := range types {
+		aStart, aEnd := o.FilterByOp(a).TimeRange()
+		for _, b := range types {
+			if a == b {
+				continue
+			}
+			bStart, bEnd := o.FilterByOp(a).TimeRange()
+			// If b starts after a, a should end before b starts
+			if bStart.After(aStart) && aEnd.After(bStart) {
+				return true
+			}
+			// a starts after b, meaning b should end before a starts
+			if bEnd.After(aStart) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ByOp separates the operations by endpoint.
 func (o Operations) ByEndpoint() map[string]Operations {
 	dst := make(map[string]Operations, 1)

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -504,6 +504,18 @@ func (o Operations) AvgSize() int64 {
 	return total / int64(len(o))
 }
 
+// AvgDuration returns the average operation duration.
+func (o Operations) AvgDuration() time.Duration {
+	if len(o) == 0 {
+		return 0
+	}
+	var total time.Duration
+	for _, op := range o {
+		total += op.Duration()
+	}
+	return total / time.Duration(len(o))
+}
+
 // SizeSegment is a size segment.
 type SizeSegment struct {
 	Smallest      int64

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -361,7 +361,7 @@ func (o Operations) FilterInsideRange(start, end time.Time) Operations {
 func (o Operations) FilterByOp(opType string) Operations {
 	dst := make(Operations, 0, len(o))
 	for _, o := range o {
-		if o.OpType == opType {
+		if o.OpType == opType || opType == "" {
 			dst = append(dst, o)
 		}
 	}


### PR DESCRIPTION
10000 operations are generated based on the distribution requests. The order of the operations is randomized. This buffer is then used in order with wraparound to ensure consistent use of operations.

All 'live' objects are placed in an array and a random object is returned on every request. 

Current output:
Single Host:
```
λ go build && warp analyze warp-mixed-2020-01-16[074404]-fLlE.csv.zst
Mixed operations.

Operation: GET
 * 632.28 MB/s, 354.78 obj/s (59.993s, starting 07:44:05 PST) (45.0% of operations)

Operation: STAT
 * 236.38 obj/s (59.966s, starting 07:44:05 PST) (30.0% of operations)

Operation: PUT
 * 206.11 MB/s, 118.23 obj/s (59.994s, starting 07:44:05 PST) (15.0% of operations)
Errors: 1

Operation: DELETE
 * 78.91 obj/s (59.927s, starting 07:44:05 PST) (10.0% of operations)

Cluster Total:  838.00 MB/s, 788.25 obj/s (59.783s, starting 07:44:05 PST)
```

Multiple Hosts:
```
λ warp analyze warp-mixed-2020-01-17[052518]-OywA.csv.zst                          
Mixed operations.                                                                              
                                                                                               
Operation: GET                                                                                 
 * 212.79 MB/s, 120.80 obj/s (1m59.954s, starting 05:25:19 PST) (45.0% of operations)          
                                                                                               
Throughput by host:                                                                            
 * http://127.0.0.1:9000: Avg: 115.33 MB/s, 65.98 obj/s (1m59.896s)                            
 * http://127.0.0.1:9001: Avg: 97.47 MB/s, 54.84 obj/s (1m59.954s)                             
                                                                                               
Operation: PUT                                                                                 
 * 70.36 MB/s, 40.26 obj/s (1m59.885s, starting 05:25:19 PST) (15.0% of operations)            
                                                                                               
Throughput by host:                                                                            
 * http://127.0.0.1:9000: Avg: 33.84 MB/s, 20.99 obj/s (1m59.684s)                             
 * http://127.0.0.1:9001: Avg: 36.57 MB/s, 19.29 obj/s (1m59.813s)                             
                                                                                               
Operation: STAT                                                                                
 * 80.49 obj/s (1m59.909s, starting 05:25:19 PST) (30.0% of operations)                        
                                                                                               
Throughput by host:                                                                            
 * http://127.0.0.1:9000: Avg: 44.81 obj/s (1m59.834s)                                         
 * http://127.0.0.1:9001: Avg: 35.70 obj/s (1m59.886s)                                         
                                                                                               
Operation: DELETE                                                                              
 * 26.88 obj/s (1m59.882s, starting 05:25:19 PST) (10.0% of operations)                        
                                                                                               
Throughput by host:                                                                            
 * http://127.0.0.1:9000: Avg: 15.23 obj/s (1m59.728s)                                         
 * http://127.0.0.1:9001: Avg: 11.66 obj/s (1m59.821s)                                         
                                                                                               
Cluster Total:  283.38 MB/s, 268.69 obj/s (1m59.523s, starting 05:25:19 PST)                   
 * http://127.0.0.1:9000:  149.12 MB/s, 146.96 obj/s (1m59.898s, starting 05:25:19 PST)        
 * http://127.0.0.1:9001:  134.02 MB/s, 121.48 obj/s (1m59.96s, starting 05:25:19 PST)                                                                                                        
```

Compare output:
```
λ warp cmp warp-mixed-2020-01-16[074404]-fLlE.csv.zst warp-mixed-2020-01-17[052518]-OywA.csv.zst
-------------------
Operation: GET
Operations: 21287 -> 14493
Endpoints: 1 -> 2
Duration: 1m0s -> 1m59s
* Average: -66.31% (-418.9 MB/s) throughput, -65.91% (-233.7) obj/s
* First Byte: Average: +20.416285ms (+997%), Median: +13.9629ms (+700%), Best: +1.9898ms (++Inf%), Worst: +492.4857ms (+367%)
-------------------
Operation: STAT
Operations: 14179 -> 9657
Endpoints: 1 -> 2
Duration: 59s -> 1m59s
* Average: -65.91% (-156.1) obj/s
-------------------
Operation: PUT
errors recorded in benchmark run. before: 1, after 0
-------------------
Operation: DELETE
Operations: 4731 -> 3224
Endpoints: 1 -> 2
Duration: 59s -> 1m57s
* Average: -65.96% (-52.0) obj/s
```

Multiple hosts with `-requests`. Most detailed:
```
λ warp analyze warp-mixed-2020-01-17[052518]-OywA.csv.zst -requests                                                             
Mixed operations.

Operation: GET
 * 212.79 MB/s, 120.80 obj/s (1m59.954s, starting 05:25:19 PST) (45.0% of operations)

Throughput by host:
 * http://127.0.0.1:9000: Avg: 115.33 MB/s, 65.98 obj/s (1m59.896s)
 * http://127.0.0.1:9001: Avg: 97.47 MB/s, 54.84 obj/s (1m59.954s)

Requests considered: 14418. Multiple sizes, average 1845573 bytes:

Request size  -> 10KB. Requests - 1742:
 * Throughput: Average: 234.1KB/s, 50%: 268.2KB/s, 90%: 17.5KB/s, 99%: 537.2B/s, Fastest: 3.1MB/s, Slowest: 143.2B/s
 * First Byte: Average: 19ms, Median: 14ms, Best: 2ms, Worst: 627ms

Request size 10KB -> 1MB. Requests - 7452:
 * Throughput: Average: 16.1MB/s, 50%: 16.1MB/s, 90%: 4.6MB/s, 99%: 1349.2KB/s, Fastest: 293.2MB/s, Slowest: 216.3KB/s
 * First Byte: Average: 20ms, Median: 14ms, Best: 2ms, Worst: 610ms

Request size 1MB -> 10MB. Requests - 6059:
 * Throughput: Average: 114.6MB/s, 50%: 133.2MB/s, 90%: 50.4MB/s, 99%: 11.7MB/s, Fastest: 768.5MB/s, Slowest: 1719.6KB/s
 * First Byte: Average: 26ms, Median: 18ms, Best: 2ms, Worst: 626ms

Requests by host:
 * http://127.0.0.1:9000 - 7913 requests: 
	- Avg: 24ms Fastest: 2ms Slowest: 956ms 50%: 17ms 90%: 41ms
	- First Byte: Average: 21ms, Median: 15ms, Best: 2ms, Worst: 626ms
 * http://127.0.0.1:9001 - 6580 requests: 
	- Avg: 28ms Fastest: 3ms Slowest: 627ms 50%: 20ms 90%: 45ms
	- First Byte: Average: 24ms, Median: 17ms, Best: 3ms, Worst: 627ms

Operation: PUT
 * 70.36 MB/s, 40.26 obj/s (1m59.885s, starting 05:25:19 PST) (15.0% of operations)

Throughput by host:
 * http://127.0.0.1:9000: Avg: 33.84 MB/s, 20.99 obj/s (1m59.684s)
 * http://127.0.0.1:9001: Avg: 36.57 MB/s, 19.29 obj/s (1m59.813s)

Requests considered: 4772. Multiple sizes, average 1829161 bytes:

Request size  -> 10KB. Requests - 692:
 * Throughput: Average: 37.1KB/s, 50%: 40.2KB/s, 90%: 2.8KB/s, 99%: 144.7B/s, Fastest: 414.6KB/s, Slowest: 12.2B/s

Request size 10KB -> 1MB. Requests - 2409:
 * Throughput: Average: 2.6MB/s, 50%: 2.1MB/s, 90%: 761.7KB/s, 99%: 318.0KB/s, Fastest: 21.5MB/s, Slowest: 130.7KB/s

Request size 1MB -> 10MB. Requests - 1942:
 * Throughput: Average: 23.4MB/s, 50%: 22.7MB/s, 90%: 9.2MB/s, 99%: 4.4MB/s, Fastest: 80.6MB/s, Slowest: 793.4KB/s

Requests by host:
 * http://127.0.0.1:9000 - 2519 requests: 
	- Avg: 135ms Fastest: 23ms Slowest: 1.393s 50%: 117ms 90%: 205ms
 * http://127.0.0.1:9001 - 2317 requests: 
	- Avg: 150ms Fastest: 45ms Slowest: 1.359s 50%: 129ms 90%: 226ms

Operation: STAT
 * 80.49 obj/s (1m59.909s, starting 05:25:19 PST) (30.0% of operations)

Throughput by host:
 * http://127.0.0.1:9000: Avg: 44.81 obj/s (1m59.834s)
 * http://127.0.0.1:9001: Avg: 35.70 obj/s (1m59.886s)

Requests considered: 9572:
 * Avg: 11ms 50%: 9ms 90%: 18ms 99%: 48ms Fastest: 1ms Slowest: 524ms

Requests by host:
 * http://127.0.0.1:9000 - 5373 requests: 
	- Avg: 8ms Fastest: 1ms Slowest: 524ms 50%: 6ms 90%: 14ms
 * http://127.0.0.1:9001 - 4284 requests: 
	- Avg: 14ms Fastest: 2ms Slowest: 522ms 50%: 12ms 90%: 22ms

Operation: DELETE
 * 26.88 obj/s (1m59.882s, starting 05:25:19 PST) (10.0% of operations)

Throughput by host:
 * http://127.0.0.1:9000: Avg: 15.23 obj/s (1m59.728s)
 * http://127.0.0.1:9001: Avg: 11.66 obj/s (1m59.821s)

Requests considered: 3150:
 * Avg: 83ms 50%: 74ms 90%: 120ms 99%: 287ms Fastest: 8ms Slowest: 1.148s

Requests by host:
 * http://127.0.0.1:9000 - 1825 requests: 
	- Avg: 78ms Fastest: 8ms Slowest: 1.148s 50%: 70ms 90%: 113ms
 * http://127.0.0.1:9001 - 1399 requests: 
	- Avg: 89ms Fastest: 20ms Slowest: 786ms 50%: 81ms 90%: 126ms

Cluster Total:  283.38 MB/s, 268.69 obj/s (1m59.523s, starting 05:25:19 PST)
 * http://127.0.0.1:9000:  149.12 MB/s, 146.96 obj/s (1m59.898s, starting 05:25:19 PST)
 * http://127.0.0.1:9001:  134.02 MB/s, 121.48 obj/s (1m59.96s, starting 05:25:19 PST) 
```
