### PR TITLE
Fix mixed mode detection

### DIFF
--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -420,13 +420,14 @@ func (o Operations) IsMultiOp() bool {
 			if a == b {
 				continue
 			}
-			bStart, bEnd := o.FilterByOp(a).TimeRange()
-			// If b starts after a, a should end before b starts
-			if bStart.After(aStart) && aEnd.After(bStart) {
-				return true
+			bStart, bEnd := o.FilterByOp(b).TimeRange()
+
+			// Make a be the first.
+			if bStart.Before(aStart) {
+				aStart, aEnd, bStart, bEnd = bStart, bEnd, aStart, aEnd
 			}
-			// a starts after b, meaning b should end before a starts
-			if bEnd.After(aStart) {
+
+			if aEnd.After(bStart) {
 				return true
 			}
 		}

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -423,7 +423,6 @@ func (o Operations) IsMultiOp() bool {
 			bStart, bEnd := o.FilterByOp(b).TimeRange()
 			firstEnd, secondStart := aEnd, bEnd
 
-			// Make 'a' be the first.
 			if bStart.Before(aStart) {
 				firstEnd, secondStart = bEnd, aStart
 			}

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -421,13 +421,14 @@ func (o Operations) IsMultiOp() bool {
 				continue
 			}
 			bStart, bEnd := o.FilterByOp(b).TimeRange()
+			firstEnd, secondStart := aEnd, bEnd
 
-			// Make a be the first.
+			// Make 'a' be the first.
 			if bStart.Before(aStart) {
-				aStart, aEnd, bStart, bEnd = bStart, bEnd, aStart, aEnd
+				firstEnd, secondStart = bEnd, aStart
 			}
 
-			if aEnd.After(bStart) {
+			if firstEnd.After(secondStart) {
 				return true
 			}
 		}


### PR DESCRIPTION
Wrong operation used. Simplify detection.

Fixes #32

```
λ go build && warp analyze warp-remote-2020-01-27[153310]-UU0l.csv.zst               
-------------------                                                                  
Skipping PUT too few samples.                                                        
-------------------                                                                  
Operation: GET. Concurrency: 48. Hosts: 1.                                           
* Average: 1286.26 MB/s, 128.63 obj/s (8.905s, starting 15:33:00 PST)                
                                                                                     
Aggregated Throughput, split into 8 x 1s time segments:                              
 * Fastest: 1391.13 MB/s, 139.11 obj/s (1s, starting 15:33:07 PST)                   
 * 50% Median: 1306.80 MB/s, 130.68 obj/s (1s, starting 15:33:02 PST)                
 * Slowest: 1140.30 MB/s, 114.03 obj/s (1s, starting 15:33:01 PST)                   
                                                                                     
λ go build && warp analyze warp-mixed-2020-01-16[074134]-k486.csv.zst                
Mixed operations.                                                                    
                                                                                     
Operation: PUT                                                                       
 * 204.46 MB/s, 113.92 obj/s (59.985s, starting 07:41:35 PST) (15.0% of operations)  
Errors: 5                                                                            
                                                                                     
Operation: STAT                                                                      
 * 227.69 obj/s (59.991s, starting 07:41:35 PST) (30.0% of operations)               
Errors: 5                                                                            
                                                                                     
Operation: GET                                                                       
 * 599.65 MB/s, 341.67 obj/s (59.996s, starting 07:41:35 PST) (45.0% of operations)  
Errors: 4                                                                            
                                                                                     
Operation: DELETE                                                                    
 * 75.80 obj/s (59.985s, starting 07:41:35 PST) (10.0% of operations)                
                                                                                     
Cluster Total:  803.87 MB/s, 759.01 obj/s (59.841s, starting 07:41:35 PST)                                                                                                
```