### PR TITLE
When cleaning up, do cleanup by prefix

### DIFF
--- a/pkg/bench/benchmark.go
+++ b/pkg/bench/benchmark.go
@@ -19,6 +19,7 @@ package bench
 import (
 	"context"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/minio/mc/pkg/console"
@@ -112,34 +113,48 @@ func (c *Common) createEmptyBucket(ctx context.Context) error {
 }
 
 // deleteAllInBucket will delete all content in a bucket.
-func (c *Common) deleteAllInBucket(ctx context.Context) {
+// If no prefixes are specified everything in bucket is deleted.
+func (c *Common) deleteAllInBucket(ctx context.Context, prefixes ...string) {
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 	cl, done := c.Client()
 	defer done()
-	objects := cl.ListObjectsV2(c.Bucket, "", true, doneCh)
+	if len(prefixes) == 0 {
+		prefixes = []string{""}
+	}
+	var wg sync.WaitGroup
 	remove := make(chan string, 1)
 	errCh := cl.RemoveObjectsWithContext(ctx, c.Bucket, remove)
-	for {
-		select {
-		case obj, ok := <-objects:
-			if !ok {
-				close(remove)
-				// Wait for deletes to finish
-				err := <-errCh
-				if err.Err != nil {
-					console.Error(err.Err)
+	wg.Add(len(prefixes))
+	for _, prefix := range prefixes {
+		go func(prefix string) {
+			defer wg.Done()
+			objects := cl.ListObjectsV2(c.Bucket, prefix, true, doneCh)
+			for {
+				select {
+				case obj, ok := <-objects:
+					if !ok {
+						return
+					}
+					if obj.Err != nil {
+						console.Error(obj.Err)
+					}
+					remove <- obj.Key
+				case err := <-errCh:
+					console.Error(err)
 				}
-				return
 			}
-			if obj.Err != nil {
-				console.Error(obj.Err)
-			}
-			remove <- obj.Key
-		case err := <-errCh:
-			console.Error(err)
-		}
+		}(prefix)
 	}
+	wg.Wait()
+	// Signal we are done
+	close(remove)
+	// Wait for deletes to finish
+	err := <-errCh
+	if err.Err != nil {
+		console.Error(err.Err)
+	}
+
 }
 
 // prepareProgress updates preparation progess with the value 0->1.

--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -33,7 +33,7 @@ type Delete struct {
 	CreateObjects int
 	BatchSize     int
 	Collector     *Collector
-	objects       []generator.Object
+	objects       generator.Objects
 
 	Common
 }
@@ -207,5 +207,7 @@ func (d *Delete) Start(ctx context.Context, wait chan struct{}) (Operations, err
 
 // Cleanup deletes everything uploaded to the bucket.
 func (d *Delete) Cleanup(ctx context.Context) {
-	d.deleteAllInBucket(ctx)
+	if len(d.objects) > 0 {
+		d.deleteAllInBucket(ctx, d.objects.Prefixes()...)
+	}
 }

--- a/pkg/bench/get.go
+++ b/pkg/bench/get.go
@@ -34,7 +34,7 @@ import (
 type Get struct {
 	CreateObjects int
 	Collector     *Collector
-	objects       []generator.Object
+	objects       generator.Objects
 
 	// Default Get options.
 	GetOpts minio.GetObjectOptions
@@ -207,5 +207,5 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 
 // Cleanup deletes everything uploaded to the bucket.
 func (g *Get) Cleanup(ctx context.Context) {
-	g.deleteAllInBucket(ctx)
+	g.deleteAllInBucket(ctx, g.objects.Prefixes()...)
 }

--- a/pkg/bench/list.go
+++ b/pkg/bench/list.go
@@ -32,7 +32,7 @@ type List struct {
 	CreateObjects int
 	NoPrefix      bool
 	Collector     *Collector
-	objects       [][]generator.Object
+	objects       []generator.Objects
 
 	Common
 }
@@ -53,7 +53,7 @@ func (d *List) Prepare(ctx context.Context) error {
 	var wg sync.WaitGroup
 	wg.Add(d.Concurrency)
 	d.Collector = NewCollector()
-	d.objects = make([][]generator.Object, d.Concurrency)
+	d.objects = make([]generator.Objects, d.Concurrency)
 	var mu sync.Mutex
 	var groupErr error
 	for i := 0; i < d.Concurrency; i++ {
@@ -211,5 +211,5 @@ func (d *List) Start(ctx context.Context, wait chan struct{}) (Operations, error
 
 // Cleanup deletes everything uploaded to the bucket.
 func (d *List) Cleanup(ctx context.Context) {
-	d.deleteAllInBucket(ctx)
+	d.deleteAllInBucket(ctx, generator.MergeObjectPrefixes(d.objects)...)
 }

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -82,6 +82,14 @@ func (m *MixedDistribution) Generate(allocObjs int) error {
 	return nil
 }
 
+func (m *MixedDistribution) Objects() generator.Objects {
+	res := make(generator.Objects, 0, len(m.objects))
+	for _, v := range m.objects {
+		res = append(res, v)
+	}
+	return res
+}
+
 func (m *MixedDistribution) normalize() error {
 	total := 0.0
 	for op, dist := range m.Distribution {
@@ -362,5 +370,5 @@ func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 
 // Cleanup deletes everything uploaded to the bucket.
 func (g *Mixed) Cleanup(ctx context.Context) {
-	g.deleteAllInBucket(ctx)
+	g.deleteAllInBucket(ctx, g.Dist.Objects().Prefixes()...)
 }

--- a/pkg/bench/stat.go
+++ b/pkg/bench/stat.go
@@ -32,7 +32,7 @@ import (
 type Stat struct {
 	CreateObjects int
 	Collector     *Collector
-	objects       []generator.Object
+	objects       generator.Objects
 
 	// Default Stat options.
 	StatOpts minio.StatObjectOptions
@@ -180,5 +180,5 @@ func (g *Stat) Start(ctx context.Context, wait chan struct{}) (Operations, error
 
 // Cleanup deletes everything uploaded to the bucket.
 func (g *Stat) Cleanup(ctx context.Context) {
-	g.deleteAllInBucket(ctx)
+	g.deleteAllInBucket(ctx, g.objects.Prefixes()...)
 }

--- a/pkg/generator/csv.go
+++ b/pkg/generator/csv.go
@@ -157,3 +157,7 @@ func (c *csvSource) Object() *Object {
 func (c *csvSource) String() string {
 	return fmt.Sprintf("CSV data. %d columns, %d rows.", c.o.csv.cols, c.o.csv.rows)
 }
+
+func (c *csvSource) Prefix() string {
+	return c.obj.PreFix
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"math/rand"
+	"runtime"
 )
 
 // Option provides options for data generation.
@@ -34,6 +35,9 @@ type Source interface {
 
 	// String returns a human readable description of the source.
 	String() string
+
+	// Prefix returns the prefix if any.
+	Prefix() string
 }
 
 type Object struct {
@@ -51,6 +55,37 @@ type Object struct {
 	Size int64
 
 	PreFix string
+}
+
+// Objects is a slice of objects.
+type Objects []Object
+
+// Prefixes returns all prefixes.
+func (o Objects) Prefixes() []string {
+	prefixes := make(map[string]struct{}, runtime.GOMAXPROCS(0))
+	for _, p := range o {
+		prefixes[p.PreFix] = struct{}{}
+	}
+	res := make([]string, 0, len(prefixes))
+	for p := range prefixes {
+		res = append(res, p)
+	}
+	return res
+}
+
+// MergeObjectPrefixes merges prefixes from several slices of objects.
+func MergeObjectPrefixes(o []Objects) []string {
+	prefixes := make(map[string]struct{}, runtime.GOMAXPROCS(0))
+	for _, objs := range o {
+		for _, p := range objs {
+			prefixes[p.PreFix] = struct{}{}
+		}
+	}
+	res := make([]string, 0, len(prefixes))
+	for p := range prefixes {
+		res = append(res, p)
+	}
+	return res
 }
 
 func (o *Object) setPrefix(opts Options) {

--- a/pkg/generator/random.go
+++ b/pkg/generator/random.go
@@ -166,3 +166,7 @@ func (r *randomSrc) String() string {
 	}
 	return fmt.Sprintf("Random data; %d bytes total, %d byte buffer", r.buf.want, len(r.buf.data))
 }
+
+func (r *randomSrc) Prefix() string {
+	return r.obj.PreFix
+}


### PR DESCRIPTION
This should speed up cleanup and also make it so distributed mode doesn't overlap eachother.