### PR TITLE
Pin goreleaser to hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.13.x
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@53acad1befee355d46f71cccf6ab4d885eb4f77f
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Re https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

This is v1.2.1 release.