### PR TITLE
Add Region option and hidden signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ S3 benchmarking tool.
 
 # configuration
 
-Warp can be configured either using commandline parameters or environment variables. The S3 server to use can be specified on the commandline using `--host`, `--access-key`, `--secret-key` and optionally `--tls` to specify TLS.
+Warp can be configured either using commandline parameters or environment variables. The S3 server to use can be specified on the commandline using `--host`, `--access-key`, `--secret-key` and optionally `--tls` and `--region` to specify TLS and a custom region.
 
-It is also possible to set the same parameters using the `WARP_HOST`, `WARP_ACCESS_KEY`, `WARP_SECRET_KEY` and `WARP_TLS` environment variables.
+It is also possible to set the same parameters using the `WARP_HOST`, `WARP_ACCESS_KEY`, `WARP_SECRET_KEY`, `WARP_REGION` and `WARP_TLS` environment variables.
 
 The credentials must be able to create, delete and list buckets and upload files and perform the operation requested.
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -138,6 +138,17 @@ var ioFlags = []cli.Flag{
 		Usage:  "Use TLS (HTTPS) for transport",
 		EnvVar: appNameUC + "_TLS",
 	},
+	cli.StringFlag{
+		Name:   "region",
+		Usage:  "Specify a custom region",
+		EnvVar: appNameUC + "_REGION",
+	},
+	cli.StringFlag{
+		Name:   "signature",
+		Usage:  "Specify a signature method. Available values are S3V2, S3V4",
+		Value:  "S3V4",
+		Hidden: true,
+	},
 	cli.BoolFlag{
 		Name:  "encrypt",
 		Usage: "encrypt/decrypt objects (using server-side encryption with random keys)",


### PR DESCRIPTION
Add `--region=us-west-1` and hidden `--signature=S3V4` parameters.

The signature is hidden since it is unlikely to be needed. We could add it to the documentation if it pops up regularly.

Fixes #51