### PR TITLE
Add skipped operation

### DIFF
--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -127,6 +127,7 @@ func Aggregate(o bench.Operations, segmentDur, skipDur time.Duration) Aggregated
 		})
 		if len(segs) <= 1 {
 			a.Skipped = true
+			res = append(res, a)
 			continue
 		}
 		total := ops.Total(!isMixed)


### PR DESCRIPTION
Otherwise they are simply excluded from the results and will not be printed.