### PR TITLE
Adjust error reporting

### DIFF
--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -95,7 +95,6 @@ func (d *Delete) Prepare(ctx context.Context) error {
 					}
 					mu.Unlock()
 					return
-
 				}
 				if n != obj.Size {
 					err := fmt.Errorf("short upload. want: %d, got %d", obj.Size, n)

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -82,13 +82,14 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 					console.Errorln("upload error:", err)
 					op.Err = err.Error()
 				}
-				if n != obj.Size {
+				if n != obj.Size && op.Err == "" {
 					err := fmt.Sprint("short upload. want:", obj.Size, ", got:", n)
 					if op.Err == "" {
 						op.Err = err
 					}
 					console.Errorln(err)
 				}
+				op.Size = n
 				cldone()
 				rcv <- op
 			}

--- a/pkg/bench/select.go
+++ b/pkg/bench/select.go
@@ -172,6 +172,7 @@ func (g *Select) Start(ctx context.Context, wait chan struct{}) (Operations, err
 				if _, err = io.Copy(ioutil.Discard, &fbr); err != nil {
 					console.Errorln("download error:", err)
 					op.Err = err.Error()
+					op.Size = 0
 				}
 				op.FirstByte = fbr.t
 				op.End = time.Now()


### PR DESCRIPTION
* PUT: Don't display short upload if another error.
* PUT: Set size to returned returned value.
* SELECT: Set size of operation to 0 on error.

Fixes #91 also.