### PR TITLE
Add --md5 option

### DIFF
--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -237,7 +237,7 @@ func runBench(ctx *cli.Context, b bench.Benchmark) error {
 	} else {
 		func() {
 			defer f.Close()
-			enc, err := zstd.NewWriter(f)
+			enc, err := zstd.NewWriter(f, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
 			fatalIf(probe.NewError(err), "Unable to compress benchmark output")
 
 			defer enc.Close()
@@ -408,7 +408,7 @@ func runClientBenchmark(ctx *cli.Context, b bench.Benchmark, cb *clientBenchmark
 	} else {
 		func() {
 			defer f.Close()
-			enc, err := zstd.NewWriter(f)
+			enc, err := zstd.NewWriter(f, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
 			fatalIf(probe.NewError(err), "Unable to compress benchmark output")
 
 			defer enc.Close()

--- a/cli/benchserver.go
+++ b/cli/benchserver.go
@@ -192,7 +192,7 @@ func runServerBenchmark(ctx *cli.Context) (bool, error) {
 	} else {
 		func() {
 			defer f.Close()
-			enc, err := zstd.NewWriter(f)
+			enc, err := zstd.NewWriter(f, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
 			fatalIf(probe.NewError(err), "Unable to compress benchmark output")
 
 			defer enc.Close()

--- a/cli/client.go
+++ b/cli/client.go
@@ -159,7 +159,9 @@ func getClient(ctx *cli.Context, host string) (*minio.Client, error) {
 		Creds:        creds,
 		Secure:       ctx.Bool("tls"),
 		Region:       ctx.String("region"),
-		BucketLookup: 0,
+		BucketLookup: minio.BucketLookupAuto,
+		// TODO(klauspost): Enable when https://github.com/minio/minio-go/pull/1283 is available
+		// CustomMD5:    md5simd.NewServer().NewHash,
 	})
 	if err != nil {
 		return nil, err

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -19,7 +19,6 @@ package cli
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/minio-go/v6"
 	"github.com/minio/minio/pkg/console"
 	"github.com/minio/warp/pkg/bench"
 )
@@ -40,10 +39,6 @@ var (
 			Name:  "batch",
 			Value: 100,
 			Usage: "Number of DELETE operations per batch.",
-		},
-		cli.BoolFlag{
-			Name:  "disable-multipart",
-			Usage: "disable multipart uploads",
 		},
 	}
 )
@@ -82,10 +77,7 @@ func mainDelete(ctx *cli.Context) error {
 			Source:      src,
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
-			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: newSSE(ctx),
-				DisableMultipart:     ctx.Bool("disable-multipart"),
-			},
+			PutOpts:     putOpts(ctx),
 		},
 		CreateObjects: ctx.Int("objects"),
 		BatchSize:     ctx.Int("batch"),

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -173,4 +173,12 @@ var ioFlags = []cli.Flag{
 		Name:  "noprefix",
 		Usage: "Do not use separate prefix for each thread",
 	},
+	cli.BoolFlag{
+		Name:  "disable-multipart",
+		Usage: "disable multipart uploads",
+	},
+	cli.BoolFlag{
+		Name:  "md5",
+		Usage: "Add MD5 sum to uploads",
+	},
 }

--- a/cli/get.go
+++ b/cli/get.go
@@ -36,10 +36,6 @@ var (
 			Value: "10MiB",
 			Usage: "Size of each generated object. Can be a number or 10KiB/MiB/GiB. All sizes are base 2 binary.",
 		},
-		cli.BoolFlag{
-			Name:  "disable-multipart",
-			Usage: "disable multipart uploads",
-		},
 	}
 )
 
@@ -76,10 +72,7 @@ func mainGet(ctx *cli.Context) error {
 			Source:      src,
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
-			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: sse,
-				DisableMultipart:     ctx.Bool("disable-multipart"),
-			},
+			PutOpts:     putOpts(ctx),
 		},
 		CreateObjects: ctx.Int("objects"),
 		GetOpts:       minio.GetObjectOptions{ServerSideEncryption: sse},

--- a/cli/list.go
+++ b/cli/list.go
@@ -19,7 +19,6 @@ package cli
 
 import (
 	"github.com/minio/cli"
-	"github.com/minio/minio-go/v6"
 	"github.com/minio/minio/pkg/console"
 	"github.com/minio/warp/pkg/bench"
 )
@@ -35,10 +34,6 @@ var (
 			Name:  "obj.size",
 			Value: "1KB",
 			Usage: "Size of each generated object. Can be a number or 10KB/MB/GB. All sizes are base 2 binary.",
-		},
-		cli.BoolFlag{
-			Name:  "disable-multipart",
-			Usage: "disable multipart uploads",
 		},
 	}
 )
@@ -76,10 +71,7 @@ func mainList(ctx *cli.Context) error {
 			Source:      src,
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
-			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: newSSE(ctx),
-				DisableMultipart:     ctx.Bool("disable-multipart"),
-			},
+			PutOpts:     putOpts(ctx),
 		},
 		CreateObjects: ctx.Int("objects"),
 		NoPrefix:      ctx.Bool("noprefix"),

--- a/cli/merge.go
+++ b/cli/merge.go
@@ -100,7 +100,7 @@ func mainMerge(ctx *cli.Context) error {
 	} else {
 		func() {
 			defer f.Close()
-			enc, err := zstd.NewWriter(f)
+			enc, err := zstd.NewWriter(f, zstd.WithEncoderLevel(zstd.SpeedBetterCompression))
 			fatalIf(probe.NewError(err), "Unable to compress benchmark output")
 
 			defer enc.Close()

--- a/cli/mixed.go
+++ b/cli/mixed.go
@@ -59,10 +59,6 @@ var (
 			Usage: "The amount of DELETE operations. Must be at least the same as PUT.",
 			Value: 10,
 		},
-		cli.BoolFlag{
-			Name:  "disable-multipart",
-			Usage: "disable multipart uploads",
-		},
 	}
 )
 
@@ -109,10 +105,7 @@ func mainMixed(ctx *cli.Context) error {
 			Source:      src,
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
-			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: sse,
-				DisableMultipart:     ctx.Bool("disable-multipart"),
-			},
+			PutOpts:     putOpts(ctx),
 		},
 		CreateObjects: ctx.Int("objects"),
 		GetOpts:       minio.GetObjectOptions{ServerSideEncryption: sse},

--- a/cli/put.go
+++ b/cli/put.go
@@ -31,10 +31,6 @@ var (
 			Value: "10MiB",
 			Usage: "Size of each generated object. Can be a number or 10KiB/MiB/GiB. All sizes are base 2 binary.",
 		},
-		cli.BoolFlag{
-			Name:  "disable-multipart",
-			Usage: "disable multipart uploads",
-		},
 	}
 )
 
@@ -64,7 +60,6 @@ EXAMPLES:
 func mainPut(ctx *cli.Context) error {
 	checkPutSyntax(ctx)
 	src := newGenSource(ctx)
-	sse := newSSE(ctx)
 	b := bench.Put{
 		Common: bench.Common{
 			Client:      newClient(ctx),
@@ -72,13 +67,19 @@ func mainPut(ctx *cli.Context) error {
 			Source:      src,
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
-			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: sse,
-				DisableMultipart:     ctx.Bool("disable-multipart"),
-			},
+			PutOpts:     putOpts(ctx),
 		},
 	}
 	return runBench(ctx, &b)
+}
+
+// putOpts retrieves put options from the context.
+func putOpts(ctx *cli.Context) minio.PutObjectOptions {
+	return minio.PutObjectOptions{
+		ServerSideEncryption: newSSE(ctx),
+		DisableMultipart:     ctx.Bool("disable-multipart"),
+		SendContentMd5:       ctx.Bool("md5"),
+	}
 }
 
 func checkPutSyntax(ctx *cli.Context) {

--- a/cli/select.go
+++ b/cli/select.go
@@ -40,10 +40,6 @@ var (
 			Value: "select * from s3object",
 			Usage: "select query expression",
 		},
-		cli.BoolFlag{
-			Name:  "disable-multipart",
-			Usage: "disable multipart uploads",
-		},
 	}
 )
 
@@ -80,10 +76,7 @@ func mainSelect(ctx *cli.Context) error {
 			Source:      src,
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
-			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: sse,
-				DisableMultipart:     ctx.Bool("disable-multipart"),
-			},
+			PutOpts:     putOpts(ctx),
 		},
 		CreateObjects: ctx.Int("objects"),
 		SelectOpts: minio.SelectObjectOptions{

--- a/cli/stat.go
+++ b/cli/stat.go
@@ -36,10 +36,6 @@ var (
 			Value: "1KB",
 			Usage: "Size of each generated object. Can be a number or 10KB/MB/GB. All sizes are base 2 binary.",
 		},
-		cli.BoolFlag{
-			Name:  "disable-multipart",
-			Usage: "disable multipart uploads",
-		},
 	}
 )
 
@@ -77,10 +73,7 @@ func mainStat(ctx *cli.Context) error {
 			Source:      src,
 			Bucket:      ctx.String("bucket"),
 			Location:    "",
-			PutOpts: minio.PutObjectOptions{
-				ServerSideEncryption: sse,
-				DisableMultipart:     ctx.Bool("disable-multipart"),
-			},
+			PutOpts:     putOpts(ctx),
 		},
 		CreateObjects: ctx.Int("objects"),
 		StatOpts: minio.StatObjectOptions{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.7.0
 	github.com/gorilla/websocket v1.4.1
-	github.com/klauspost/compress v1.10.3
+	github.com/klauspost/compress v1.10.5
 	github.com/minio/cli v1.22.0
 	github.com/minio/mc v0.0.0-20200201185513-ac9b9423973b
 	github.com/minio/minio v0.0.0-20200430053134-c7470e6e6eed
@@ -16,3 +16,5 @@ require (
 	github.com/posener/complete v1.2.2-0.20190702141536-6ffe496ea953
 	github.com/secure-io/sio-go v0.3.0
 )
+
+replace github.com/minio/minio-go/v6 v6.0.55 => ../minio-go

--- a/go.sum
+++ b/go.sum
@@ -155,7 +155,11 @@ github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/compress v1.10.1/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eTO0Q8=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.10.5 h1:7q6vHIqubShURwQz8cQK6yIe/xC3IF0Vm7TGfqjewrc=
+github.com/klauspost/compress v1.10.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v1.2.2/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid v1.2.3 h1:CCtW0xUnWGVINKvE/WWOYKdsPV6mawAtvQuSl8guwQs=
+github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.1/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/readahead v1.3.1/go.mod h1:AH9juHzNH7xqdqFHrMRSHeH2Ps+vFf+kblDqzPFiLJg=
 github.com/klauspost/reedsolomon v1.9.3/go.mod h1:CwCi+NUr9pqSVktrkN+Ondf06rkhYZ/pcNv7fu+8Un4=
@@ -192,6 +196,8 @@ github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5
 github.com/minio/lsync v1.0.1/go.mod h1:tCFzfo0dlvdGl70IT4IAK/5Wtgb0/BrTmo/jE8pArKA=
 github.com/minio/mc v0.0.0-20200201185513-ac9b9423973b h1:siZdh/8+duokEXM1sae3ZcPorS0v0oviNmJZpqEGtkw=
 github.com/minio/mc v0.0.0-20200201185513-ac9b9423973b/go.mod h1:ep2NdB/OnxDSd7NbpBz6ickqPhZunIsc5+WkLrKMXBA=
+github.com/minio/md5-simd v1.0.1 h1:tj/FH8APTKxIkOGUX2YGAVJVXXC3AJ5T2SkHoT/dUFI=
+github.com/minio/md5-simd v1.0.1/go.mod h1:EhdyA+Dr0guvfyc8d6yrgs9YzHGfaI+YIjA6gt/7mJk=
 github.com/minio/minio v0.0.0-20200118222113-b849fd7a756d/go.mod h1:f8MCueGjpibyBY0iVthLZPcrz310Dgwe/Knx+Dx/2+A=
 github.com/minio/minio v0.0.0-20200430053134-c7470e6e6eed h1:J/3xqGykZ2kNTCJC71XmSLeNZjudDDMHG5teMtEmLkc=
 github.com/minio/minio v0.0.0-20200430053134-c7470e6e6eed/go.mod h1:Vhlqz7Se0EgpgFiVxpvzF4Zz/h2LMx+EPKH96Aera5U=
@@ -274,6 +280,7 @@ github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190704165056-9c2d0518ed81/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -863,6 +863,7 @@ func OperationsFromCSV(r io.Reader) (Operations, error) {
 	cr := csv.NewReader(r)
 	cr.Comma = '\t'
 	cr.ReuseRecord = true
+	cr.Comment = '#'
 	header, err := cr.Read()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Bonus changes:
* Compress output a bit better
* Clean up put options
* Move `disable-multipart` to IO options
* Add comment value for CSV input, so we can add stuff like cmdline to output later.

Waiting for https://github.com/minio/minio-go/pull/1283