### PR TITLE
Fix single host mixed throughput

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -176,8 +176,12 @@ func printMixedOpAnalysis(ctx *cli.Context, aggr aggregate.Aggregated) {
 			}
 			console.SetColor("Print", color.New(color.FgWhite))
 		}
+		eps := ops.ThroughputByHost
+		if len(eps) == 1 {
+			console.Println(" * Throughput:", ops.Throughput)
+		}
 
-		if eps := ops.ThroughputByHost; len(eps) > 1 {
+		if len(eps) > 1 {
 			console.SetColor("Print", color.New(color.FgWhite))
 			console.Println("\nThroughput by host:")
 


### PR DESCRIPTION
When only one host was present no statistics is being written:

Before:
```
e:\gopath\src\github.com\minio\warp (master -> origin)
λ go build && warp analyze warp-mixed-2020-05-04[204454]-2F3x.csv.zst
Mixed operations.

Operation: GET
 * Operations: 13612 (47.5% of operations)

Operation: STAT
 * Operations: 9074 (31.7% of operations)

Operation: DELETE
 * Operations: 3016 (10.5% of operations)

Operation: PUT
 * Operations: 4501 (15.7% of operations)

Cluster Total:  501.15 MiB/s, 999.38 obj/s (28.691s, starting 20:44:57 CEST)
```

After:
```
λ go build && warp analyze warp-mixed-2020-05-04[204454]-2F3x.csv.zst
Mixed operations.

Operation: GET
 * Operations: 13612 (47.5% of operations)
 * Throughput: 379.00 MiB/s, 454.05 obj/s (29.988s, starting 20:44:57 CEST)

Operation: STAT
 * Operations: 9074 (31.7% of operations)
 * Throughput: 302.69 obj/s (29.986s, starting 20:44:57 CEST)

Operation: DELETE
 * Operations: 3016 (10.5% of operations)
 * Throughput: 100.68 obj/s (29.976s, starting 20:44:57 CEST)

Operation: PUT
 * Operations: 4501 (15.7% of operations)
 * Throughput: 128.18 MiB/s, 150.89 obj/s (29.973s, starting 20:44:57 CEST)

Cluster Total:  501.15 MiB/s, 999.38 obj/s (28.691s, starting 20:44:57 CEST)
```

Fixes #105 