### PR TITLE
Fix GET memory leak

### DIFF
--- a/pkg/bench/get.go
+++ b/pkg/bench/get.go
@@ -178,7 +178,7 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 				}
 				op.Start = time.Now()
 				var err error
-				fbr.r, err = client.GetObject(g.Bucket, obj.Name, opts)
+				o, err := client.GetObject(g.Bucket, obj.Name, opts)
 				if err != nil {
 					console.Errorln("download error:", err)
 					op.Err = err.Error()
@@ -187,6 +187,7 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 					cldone()
 					continue
 				}
+				fbr.r = o
 				n, err := io.Copy(ioutil.Discard, &fbr)
 				if err != nil {
 					console.Errorln("download error:", err)
@@ -200,6 +201,7 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 				}
 				rcv <- op
 				cldone()
+				o.Close()
 			}
 		}(i)
 	}

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -259,7 +259,8 @@ func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 					}
 					op.Start = time.Now()
 					var err error
-					fbr.r, err = client.GetObject(g.Bucket, obj.Name, g.GetOpts)
+					o, err := client.GetObject(g.Bucket, obj.Name, g.GetOpts)
+					fbr.r = o
 					if err != nil {
 						console.Errorln("download error:", err)
 						op.Err = err.Error()
@@ -283,6 +284,8 @@ func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 					rcv <- op
 					objDone()
 					clDone()
+					o.Close()
+
 				case http.MethodPut:
 					obj := src.Object()
 					putOpts.ContentType = obj.ContentType

--- a/pkg/bench/select.go
+++ b/pkg/bench/select.go
@@ -160,7 +160,8 @@ func (g *Select) Start(ctx context.Context, wait chan struct{}) (Operations, err
 				}
 				op.Start = time.Now()
 				var err error
-				fbr.r, err = client.SelectObjectContent(context.Background(), g.Bucket, obj.Name, opts)
+				o, err := client.SelectObjectContent(context.Background(), g.Bucket, obj.Name, opts)
+				fbr.r = o
 				if err != nil {
 					console.Errorln("download error:", err)
 					op.Err = err.Error()
@@ -178,6 +179,7 @@ func (g *Select) Start(ctx context.Context, wait chan struct{}) (Operations, err
 				op.End = time.Now()
 				rcv <- op
 				cldone()
+				o.Close()
 			}
 		}(i)
 	}


### PR DESCRIPTION
The returned object was not closed leading to leaks when running many operations.

Fixes #113