### PR TITLE
Add commandline to csv files

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -56,10 +56,11 @@ type Operations struct {
 
 // Server contains the state of the running server.
 type Server struct {
-	status BenchmarkStatus
-	ops    bench.Operations
-	agrr   *aggregate.Aggregated
-	server *http.Server
+	status  BenchmarkStatus
+	ops     bench.Operations
+	agrr    *aggregate.Aggregated
+	server  *http.Server
+	cmdLine string
 
 	// Shutting down
 	ctx    context.Context
@@ -73,11 +74,12 @@ type Server struct {
 }
 
 // OperationsReady can be used to send benchmark data to the server.
-func (s *Server) OperationsReady(ops bench.Operations, filename string) {
+func (s *Server) OperationsReady(ops bench.Operations, filename, cmdLine string) {
 	s.mu.Lock()
 	s.status.DataReady = ops != nil
 	s.ops = ops
 	s.status.Filename = filename
+	s.cmdLine = cmdLine
 	s.mu.Unlock()
 }
 
@@ -216,7 +218,7 @@ func (s *Server) handleDownloadZst(w http.ResponseWriter, req *http.Request) {
 	}
 	defer enc.Close()
 
-	err = ops.CSV(enc)
+	err = ops.CSV(enc, s.cmdLine)
 	if err != nil {
 		s.Errorln(err)
 		return

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -141,7 +141,7 @@ func mainAnalyze(ctx *cli.Context) error {
 		fatalIf(probe.NewError(err), "Unable to parse input")
 
 		printAnalysis(ctx, ops)
-		monitor.OperationsReady(ops, strings.TrimSuffix(filepath.Base(arg), ".csv.zst"))
+		monitor.OperationsReady(ops, strings.TrimSuffix(filepath.Base(arg), ".csv.zst"), commandLine(ctx))
 	}
 	return nil
 }

--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -244,13 +244,13 @@ func runBench(ctx *cli.Context, b bench.Benchmark) error {
 			fatalIf(probe.NewError(err), "Unable to compress benchmark output")
 
 			defer enc.Close()
-			err = ops.CSV(enc)
+			err = ops.CSV(enc, commandLine(ctx))
 			fatalIf(probe.NewError(err), "Unable to write benchmark output")
 
 			monitor.Infoln(fmt.Sprintf("Benchmark data written to %q\n", fileName+".csv.zst"))
 		}()
 	}
-	monitor.OperationsReady(ops, fileName)
+	monitor.OperationsReady(ops, fileName, commandLine(ctx))
 	printAnalysis(ctx, ops)
 	if !ctx.Bool("keep-data") && !ctx.Bool("noclear") {
 		monitor.Infoln("Starting cleanup...")
@@ -415,7 +415,7 @@ func runClientBenchmark(ctx *cli.Context, b bench.Benchmark, cb *clientBenchmark
 			fatalIf(probe.NewError(err), "Unable to compress benchmark output")
 
 			defer enc.Close()
-			err = ops.CSV(enc)
+			err = ops.CSV(enc, commandLine(ctx))
 			fatalIf(probe.NewError(err), "Unable to write benchmark output")
 
 			console.Infof("Benchmark data written to %q\n", fileName+".csv.zst")

--- a/cli/benchserver.go
+++ b/cli/benchserver.go
@@ -196,13 +196,13 @@ func runServerBenchmark(ctx *cli.Context) (bool, error) {
 			fatalIf(probe.NewError(err), "Unable to compress benchmark output")
 
 			defer enc.Close()
-			err = allOps.CSV(enc)
+			err = allOps.CSV(enc, commandLine(ctx))
 			fatalIf(probe.NewError(err), "Unable to write benchmark output")
 
 			console.Infof("Benchmark data written to %q\n", fileName+".csv.zst")
 		}()
 	}
-	monitor.OperationsReady(allOps, fileName)
+	monitor.OperationsReady(allOps, fileName, commandLine(ctx))
 	err = conns.startStageAll(stageCleanup, time.Now(), false)
 	if err != nil {
 		errorLn("Failed to clean up all clients", err)

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -19,6 +19,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/minio/cli"
@@ -115,6 +116,24 @@ func setGlobals(quiet, debug, json, noColor bool) {
 	if globalNoColor || globalQuiet {
 		console.SetColorOff()
 	}
+}
+
+// commandLine attempts to reconstruct the commandline.
+func commandLine(ctx *cli.Context) string {
+	s := os.Args[0] + " " + ctx.Command.Name
+	for _, flag := range ctx.Command.Flags {
+		val, err := flagToJSON(ctx, flag)
+		if err != nil || val == "" {
+			continue
+		}
+		name := flag.GetName()
+		switch name {
+		case "access-key", "secret-key":
+			val = "*REDACTED*"
+		}
+		s += " --" + flag.GetName() + "=" + val
+	}
+	return s
 }
 
 // Flags common across all I/O commands such as cp, mirror, stat, pipe etc.

--- a/cli/merge.go
+++ b/cli/merge.go
@@ -104,7 +104,7 @@ func mainMerge(ctx *cli.Context) error {
 			fatalIf(probe.NewError(err), "Unable to compress benchmark output")
 
 			defer enc.Close()
-			err = allOps.CSV(enc)
+			err = allOps.CSV(enc, commandLine(ctx))
 			fatalIf(probe.NewError(err), "Unable to write benchmark output")
 
 			console.Infof("Benchmark data written to %q\n", fileName+".csv.zst")

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -846,7 +847,8 @@ func (o Operations) FilterErrors() Operations {
 }
 
 // CSV will write the operations to w as CSV.
-func (o Operations) CSV(w io.Writer) error {
+// The comment, if any, is written at the end of the file, each line prefixed with '# '.
+func (o Operations) CSV(w io.Writer, comment string) error {
 	bw := bufio.NewWriter(w)
 	_, err := bw.WriteString("idx\tthread\top\tclient_id\tn_objects\tbytes\tendpoint\tfile\terror\tstart\tfirst_byte\tend\tduration_ns\n")
 	if err != nil {
@@ -862,6 +864,16 @@ func (o Operations) CSV(w io.Writer) error {
 			return err
 		}
 	}
+	if len(comment) > 0 {
+		lines := strings.Split(comment, "\n")
+		for _, txt := range lines {
+			_, err := bw.WriteString("# " + txt + "\n")
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return bw.Flush()
 }
 


### PR DESCRIPTION
When saving a csv file add commandline args to file.

`# warp put --access-key=*REDACTED* --secret-key=*REDACTED* --md5=true --duration=1s`

The reason we don't use the raw args is that this will not be correct on remote hosts.

We filter access/secret keys as can be seen in the example.

Unlisted args have default value.

Fixes #94

Comments have been ignored for several months now, so should be fine.

For now to read it, it will have to listed like this: `zstd -d -c warp-put-2020-08-13[065542]-Bf8r.csv.zst` for example.