### PR TITLE
Automatic time segment length

### DIFF
--- a/cli/cmp.go
+++ b/cli/cmp.go
@@ -115,7 +115,7 @@ func printCompare(ctx *cli.Context, before, after bench.Operations) {
 		console.Println("Operation:", typ)
 		console.SetColor("Print", color.New(color.FgWhite))
 
-		cmp, err := bench.Compare(before, after, analysisDur(ctx), !isMultiOp)
+		cmp, err := bench.Compare(before, after, analysisDur(ctx, before.Duration()), !isMultiOp)
 		if err != nil {
 			console.Println(err)
 			continue

--- a/pkg/aggregate/requests.go
+++ b/pkg/aggregate/requests.go
@@ -164,7 +164,6 @@ func RequestAnalysisHostsSingleSized(o bench.Operations) map[string]SingleSizedR
 		if len(filtered) <= 1 {
 			continue
 		}
-		filtered.SortByDuration()
 		a := SingleSizedRequests{}
 		a.fill(filtered)
 		res[ep] = a


### PR DESCRIPTION
Add automatic time segment length and optimize slice sorting.

Drastically limits the time spent analyzing very long runs and reduces time spent analyzing runs with many operations.

A 5 minute run with ~3m operations analysis time 3x faster.

Results confirmed to be the same.

Fixes #97