### PR TITLE
Do concurrent analysis

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -261,9 +261,9 @@ func printAnalysis(ctx *cli.Context, o bench.Operations) {
 		opo := ops.ObjectsPerOperation
 		console.SetColor("Print", color.New(color.FgHiWhite))
 		if opo > 1 {
-			console.Printf("Operation: %v. Objects per operation: %d. Concurrency: %d. Hosts: %d.\n", typ, opo, ops.Concurrency, ops.Hosts)
+			console.Printf("Operation: %v (%d). Objects per operation: %d. Concurrency: %d. Hosts: %d.\n", typ, ops.N, opo, ops.Concurrency, ops.Hosts)
 		} else {
-			console.Printf("Operation: %v. Concurrency: %d. Hosts: %d.\n", typ, ops.Concurrency, ops.Hosts)
+			console.Printf("Operation: %v (%d). Concurrency: %d. Hosts: %d.\n", typ, ops.N, ops.Concurrency, ops.Hosts)
 		}
 		if ops.Errors > 0 {
 			console.SetColor("Print", color.New(color.FgHiRed))

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -383,6 +383,7 @@ func (o Operations) SetClientID(id string) {
 }
 
 // FilterByEndpoint returns operations run against a specific endpoint.
+// Always returns a copy.
 func (o Operations) FilterByEndpoint(endpoint string) Operations {
 	dst := make(Operations, 0, len(o))
 	for _, o := range o {


### PR DESCRIPTION
When analysing multiple endpoints or operations do them concurrently.

Example:

```
λ warp analyze warp-versioned-2020-07-10[174722]-taQ8.csv.zst

BEFORE:

Kernel  Time =     0.375 =    5%
User    Time =     7.125 =  102%
Process Time =     7.500 =  108%    Virtual  Memory =    410 MB
Global  Time =     6.929 =  100%    Physical Memory =    386 MB

AFTER:

Kernel  Time =     0.484 =   12%
User    Time =     8.218 =  203%
Process Time =     8.703 =  215%    Virtual  Memory =    537 MB
Global  Time =     4.031 =  100%    Physical Memory =    526 MB
```

Fine wall time reduction.