### PR TITLE
Keep progress messages on single line

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -102,15 +102,15 @@ func (s *Server) Done() {
 	<-s.ctx.Done()
 }
 
-// Infoln allows to log data to the server.
+// InfoLn allows to log data to the server.
 // The server will update its status and send message upstream if set.
-func (s *Server) Infoln(data ...interface{}) {
+func (s *Server) InfoLn(data ...interface{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.infoln != nil {
 		s.infoln(data...)
 	}
-	s.status.LastStatus = strings.TrimSpace(fmt.Sprintln(data...))
+	s.status.LastStatus = strings.TrimSpace(fmt.Sprint(data...))
 }
 
 // InfoQuietln can be used to log data to the internal status only

--- a/cli/progress-bar.go
+++ b/cli/progress-bar.go
@@ -34,7 +34,7 @@ type progressBar struct {
 
 // newProgressBar - instantiate a progress bar.
 func newProgressBar(total int64, units pb.Units) *progressBar {
-	// Progress bar speific theme customization.
+	// Progress bar specific theme customization.
 	console.SetColor("Bar", color.New(color.FgGreen, color.Bold))
 
 	pgbar := progressBar{}
@@ -58,7 +58,9 @@ func newProgressBar(total int64, units pb.Units) *progressBar {
 
 	// Custom callback with colorized bar.
 	bar.Callback = func(s string) {
-		console.Print(console.Colorize("Bar", "\r"+s))
+		printMu.Lock()
+		defer printMu.Unlock()
+		console.Print(console.Colorize("Bar", "\r"+s+"\r"))
 	}
 
 	// Use different unicodes for Linux, OS X and Windows.

--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -47,7 +47,7 @@ func (d *Delete) Prepare(ctx context.Context) error {
 		return err
 	}
 	src := d.Source()
-	console.Infoln("Uploading", d.CreateObjects, "Objects of", src.String())
+	console.Info("\rUploading ", d.CreateObjects, " objects of ", src.String())
 	var wg sync.WaitGroup
 	wg.Add(d.Concurrency)
 	d.Collector = NewCollector()
@@ -88,7 +88,7 @@ func (d *Delete) Prepare(ctx context.Context) error {
 				op.End = time.Now()
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
-					console.Error(err)
+					d.Error(err)
 					mu.Lock()
 					if groupErr == nil {
 						groupErr = err
@@ -100,7 +100,7 @@ func (d *Delete) Prepare(ctx context.Context) error {
 
 				if obj.Size != obj.Size {
 					err := fmt.Errorf("short upload. want: %d, got %d", obj.Size, obj.Size)
-					console.Error(err)
+					d.Error(err)
 					mu.Lock()
 					if groupErr == nil {
 						groupErr = err
@@ -196,7 +196,7 @@ func (d *Delete) Start(ctx context.Context, wait chan struct{}) (Operations, err
 						break
 					}
 					if err.Err != nil {
-						console.Errorln(err.Err)
+						d.Error(err.Err)
 						op.Err = err.Err.Error()
 					}
 				}

--- a/pkg/bench/list.go
+++ b/pkg/bench/list.go
@@ -50,9 +50,9 @@ func (d *List) Prepare(ctx context.Context) error {
 	src := d.Source()
 	objPerPrefix := d.CreateObjects / d.Concurrency
 	if d.NoPrefix {
-		console.Infoln("Uploading", objPerPrefix*d.Concurrency, "Objects of", src.String(), "with no prefixes")
+		console.Info("\rUploading ", objPerPrefix*d.Concurrency, " objects of ", src.String(), " with no prefixes")
 	} else {
-		console.Infoln("Uploading", objPerPrefix*d.Concurrency, "Objects of", src.String(), "with", d.Concurrency, "prefixes")
+		console.Info("\rUploading ", objPerPrefix*d.Concurrency, " objects of ", src.String(), " with ", d.Concurrency, " prefixes")
 	}
 	var wg sync.WaitGroup
 	wg.Add(d.Concurrency)
@@ -100,7 +100,7 @@ func (d *List) Prepare(ctx context.Context) error {
 				op.End = time.Now()
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
-					console.Error(err)
+					d.Error(err)
 					mu.Lock()
 					if groupErr == nil {
 						groupErr = err
@@ -111,7 +111,7 @@ func (d *List) Prepare(ctx context.Context) error {
 				obj.VersionID = res.VersionID
 				if res.Size != obj.Size {
 					err := fmt.Errorf("short upload. want: %d, got %d", obj.Size, res.Size)
-					console.Error(err)
+					d.Error(err)
 					mu.Lock()
 					if groupErr == nil {
 						groupErr = err
@@ -192,7 +192,7 @@ func (d *List) Start(ctx context.Context, wait chan struct{}) (Operations, error
 						break
 					}
 					if err.Err != nil {
-						console.Errorln(err.Err)
+						d.Error(err.Err)
 						op.Err = err.Err.Error()
 					}
 					op.ObjPerOp++

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -23,8 +23,6 @@ import (
 	"net/http"
 	"sync"
 	"time"
-
-	"github.com/minio/minio/pkg/console"
 )
 
 // Put benchmarks upload speed.
@@ -83,7 +81,7 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 				res, err := client.PutObject(nonTerm, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 				op.End = time.Now()
 				if err != nil {
-					console.Errorln("upload error:", err)
+					u.Error("upload error: ", err)
 					op.Err = err.Error()
 				}
 				obj.VersionID = res.VersionID
@@ -93,7 +91,7 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 					if op.Err == "" {
 						op.Err = err
 					}
-					console.Errorln(err)
+					u.Error(err)
 				}
 				op.Size = res.Size
 				cldone()

--- a/pkg/bench/select.go
+++ b/pkg/bench/select.go
@@ -50,7 +50,7 @@ func (g *Select) Prepare(ctx context.Context) error {
 		return err
 	}
 	src := g.Source()
-	console.Infoln("Uploading", g.CreateObjects, "Objects of", src.String())
+	console.Info("\rUploading ", g.CreateObjects, " objects of ", src.String())
 	var wg sync.WaitGroup
 	wg.Add(g.Concurrency)
 	g.Collector = NewCollector()
@@ -91,7 +91,7 @@ func (g *Select) Prepare(ctx context.Context) error {
 				op.End = time.Now()
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
-					console.Error(err)
+					g.Error(err)
 					mu.Lock()
 					if groupErr == nil {
 						groupErr = err
@@ -102,7 +102,7 @@ func (g *Select) Prepare(ctx context.Context) error {
 				obj.VersionID = res.VersionID
 				if res.Size != obj.Size {
 					err := fmt.Errorf("short upload. want: %d, got %d", obj.Size, res.Size)
-					console.Error(err)
+					g.Error(err)
 					mu.Lock()
 					if groupErr == nil {
 						groupErr = err
@@ -168,7 +168,7 @@ func (g *Select) Start(ctx context.Context, wait chan struct{}) (Operations, err
 				o, err := client.SelectObjectContent(nonTerm, g.Bucket, obj.Name, opts)
 				fbr.r = o
 				if err != nil {
-					console.Errorln("download error:", err)
+					g.Error("download error: ", err)
 					op.Err = err.Error()
 					op.End = time.Now()
 					rcv <- op
@@ -176,7 +176,7 @@ func (g *Select) Start(ctx context.Context, wait chan struct{}) (Operations, err
 					continue
 				}
 				if _, err = io.Copy(ioutil.Discard, &fbr); err != nil {
-					console.Errorln("download error:", err)
+					g.Error("download error: ", err)
 					op.Err = err.Error()
 					op.Size = 0
 				}

--- a/pkg/bench/stat.go
+++ b/pkg/bench/stat.go
@@ -48,7 +48,7 @@ func (g *Stat) Prepare(ctx context.Context) error {
 		return err
 	}
 	src := g.Source()
-	console.Infoln("Uploading", g.CreateObjects, "Objects of", src.String())
+	console.Info("\rUploading ", g.CreateObjects, " objects of ", src.String())
 	var wg sync.WaitGroup
 	wg.Add(g.Concurrency)
 	g.Collector = NewCollector()
@@ -89,7 +89,7 @@ func (g *Stat) Prepare(ctx context.Context) error {
 				op.End = time.Now()
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
-					console.Error(err)
+					g.Error(err)
 					mu.Lock()
 					if groupErr == nil {
 						groupErr = err
@@ -101,7 +101,7 @@ func (g *Stat) Prepare(ctx context.Context) error {
 				obj.VersionID = res.VersionID
 				if res.Size != obj.Size {
 					err := fmt.Errorf("short upload. want: %d, got %d", obj.Size, res.Size)
-					console.Error(err)
+					g.Error(err)
 					mu.Lock()
 					if groupErr == nil {
 						groupErr = err
@@ -165,7 +165,7 @@ func (g *Stat) Start(ctx context.Context, wait chan struct{}) (Operations, error
 				opts.VersionID = obj.VersionID
 				objI, err := client.StatObject(nonTerm, g.Bucket, obj.Name, opts)
 				if err != nil {
-					console.Errorln("StatObject error:", err)
+					g.Error("StatObject error: ", err)
 					op.Err = err.Error()
 					op.End = time.Now()
 					rcv <- op
@@ -175,7 +175,7 @@ func (g *Stat) Start(ctx context.Context, wait chan struct{}) (Operations, error
 				op.End = time.Now()
 				if objI.Size != obj.Size && op.Err == "" {
 					op.Err = fmt.Sprint("unexpected file size. want:", obj.Size, ", got:", objI.Size)
-					console.Errorln(op.Err)
+					g.Error(op.Err)
 				}
 				rcv <- op
 				cldone()


### PR DESCRIPTION
Fixes #69

Example, running with no problems:

![image](https://user-images.githubusercontent.com/5663952/90517543-d46bc300-e165-11ea-8090-97390b7ece1c.png)

Errors are kept:

![image](https://user-images.githubusercontent.com/5663952/90517741-198ff500-e166-11ea-889e-73d6adc0a503.png)

When running as server:

![image](https://user-images.githubusercontent.com/5663952/90518507-295c0900-e167-11ea-9319-0a8c606c36ba.png)
