### PR TITLE
Tweak analysis

### DIFF
--- a/cli/cmp.go
+++ b/cli/cmp.go
@@ -18,9 +18,7 @@
 package cli
 
 import (
-	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -64,10 +62,8 @@ func mainCmp(ctx *cli.Context) error {
 		fatalIf(probe.NewError(err), "Unable to open input file")
 		defer f.Close()
 		err = zstdDec.Reset(f)
-		fatalIf(probe.NewError(err), "Unable to decompress input")
-		b, err := ioutil.ReadAll(zstdDec)
 		fatalIf(probe.NewError(err), "Unable to read input")
-		ops, err := bench.OperationsFromCSV(bytes.NewBuffer(b))
+		ops, err := bench.OperationsFromCSV(zstdDec, true, ctx.Int("analyze.offset"), ctx.Int("analyze.limit"))
 		fatalIf(probe.NewError(err), "Unable to parse input")
 		return ops
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -57,35 +57,41 @@ var globalFlags = []cli.Flag{
 }
 
 var profileFlags = []cli.Flag{
-	// These flags mimmic the `go test` flags.
 	cli.StringFlag{
-		Name:   "cpuprofile",
-		Value:  "",
-		Usage:  "Write a local CPU profile to the specified file before exiting.",
+		Name:   "profdir",
+		Usage:  "Write profiles to this folder",
+		Value:  "pprof",
 		Hidden: true,
 	},
-	cli.StringFlag{
-		Name:   "memprofile",
-		Value:  "",
-		Usage:  "Write an local allocation profile to the file after all tests have passed.",
+
+	cli.BoolFlag{
+		Name:   "cpu",
+		Usage:  "Write a local CPU profile",
 		Hidden: true,
 	},
-	cli.StringFlag{
-		Name:   "blockprofile",
-		Value:  "",
-		Usage:  "Write a local goroutine blocking profile to the specified file when all tests are complete.",
+	cli.BoolFlag{
+		Name:   "mem",
+		Usage:  "Write an local allocation profile",
 		Hidden: true,
 	},
-	cli.StringFlag{
-		Name:   "mutexprofile",
-		Value:  "",
-		Usage:  "Write a mutex contention profile to the specified file when all tests are complete.",
+	cli.BoolFlag{
+		Name:   "block",
+		Usage:  "Write a local goroutine blocking profile",
 		Hidden: true,
 	},
-	cli.StringFlag{
+	cli.BoolFlag{
+		Name:   "mutex",
+		Usage:  "Write a mutex contention profile",
+		Hidden: true,
+	},
+	cli.BoolFlag{
+		Name:   "threads",
+		Usage:  "Write a threas create profile",
+		Hidden: true,
+	},
+	cli.BoolFlag{
 		Name:   "trace",
-		Value:  "",
-		Usage:  "Write an local execution trace to the specified file before exiting.",
+		Usage:  "Write an local execution trace",
 		Hidden: true,
 	},
 }

--- a/cli/merge.go
+++ b/cli/merge.go
@@ -18,10 +18,8 @@
 package cli
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -75,9 +73,7 @@ func mainMerge(ctx *cli.Context) error {
 		defer f.Close()
 		err = zstdDec.Reset(f)
 		fatalIf(probe.NewError(err), "Unable to decompress input")
-		b, err := ioutil.ReadAll(zstdDec)
-		fatalIf(probe.NewError(err), "Unable to read input")
-		ops, err := bench.OperationsFromCSV(bytes.NewBuffer(b))
+		ops, err := bench.OperationsFromCSV(zstdDec, false, ctx.Int("analyze.offset"), ctx.Int("analyze.limit"))
 		fatalIf(probe.NewError(err), "Unable to parse input")
 
 		threads = ops.OffsetThreads(threads)

--- a/pkg/aggregate/throughput.go
+++ b/pkg/aggregate/throughput.go
@@ -45,21 +45,22 @@ type Throughput struct {
 
 // String returns a string representation of the segment
 func (t Throughput) String() string {
-	return t.StringDetails(true)
+	return t.StringDetails(true) + " " + t.StringDuration()
+}
+
+// StringDuration returns a string representation of the segment duration
+func (t Throughput) StringDuration() string {
+	return fmt.Sprintf("Duration: %v, starting %v", time.Duration(t.MeasureDurationMillis)*time.Millisecond, t.StartTime.Format("15:04:05 MST"))
 }
 
 // String returns a string representation of the segment
 func (t Throughput) StringDetails(details bool) string {
 	speed := ""
-	detail := ""
 	if t.AverageBPS > 0 {
 		speed = fmt.Sprintf("%.02f MiB/s, ", t.AverageBPS/(1<<20))
 	}
-	if details {
-		detail = fmt.Sprintf(" (%v, starting %v)", time.Duration(t.MeasureDurationMillis)*time.Millisecond, t.StartTime.Format("15:04:05 MST"))
-	}
-	return fmt.Sprintf("%s%.02f obj/s%s",
-		speed, t.AverageOPS, detail)
+	return fmt.Sprintf("%s%.02f obj/s",
+		speed, t.AverageOPS)
 }
 
 func (t *Throughput) fill(total bench.Segment) {

--- a/pkg/bench/analyze_test.go
+++ b/pkg/bench/analyze_test.go
@@ -37,7 +37,7 @@ func TestOperations_Segment(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ops, err := OperationsFromCSV(bytes.NewBuffer(b))
+	ops, err := OperationsFromCSV(bytes.NewBuffer(b), false, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* Load operations as stream (less memory required)
* When analyzing  only, simplify some operation parameters.
* Simplify hidden profiling. `github.com/pkg/profile` will only do one :(
* Add hidden `--analyze.offset` and `--analyze.limit` to allow loading partial sets.
* Always print duration in mixed mode.
* Print load progress.