### PR TITLE
Use Alpine as the base of the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV CGO_ENABLED=0
 
 RUN go build -ldflags '-w -s' -a -o warp .
 
-FROM scratch
+FROM alpine
 MAINTAINER MinIO Development "dev@min.io"
 EXPOSE 7761
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine
 MAINTAINER MinIO Development "dev@min.io"
 EXPOSE 7761
 COPY warp /warp


### PR DESCRIPTION
Whe running warp as a kubernetes job, if one wants to copy the results from the job out using `kubectl cp` it's not possible if the tar package is not installed in the container.

This PR switches the base image to alpine to include a set of basic tools in the warp container including the posibility of getting a shell inside the container.