### PR TITLE
Print warp client no. in detailed analysis

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -280,6 +280,9 @@ func printAnalysis(ctx *cli.Context, o bench.Operations) {
 		if ops.Hosts > 1 {
 			hostsString = fmt.Sprintf(" Hosts: %d.", ops.Hosts)
 		}
+		if ops.Clients > 1 {
+			hostsString = fmt.Sprintf("%s Warp Instances: %d.", hostsString, ops.Clients)
+		}
 		if opo > 1 {
 			if details {
 				console.Printf("Operation: %v (%d). Objects per operation: %d. Concurrency: %d.%s\n", typ, ops.N, opo, ops.Concurrency, hostsString)

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -51,6 +51,8 @@ type Operation struct {
 	ObjectsPerOperation int `json:"objects_per_operation"`
 	// Concurrency - total number of threads running.
 	Concurrency int `json:"concurrency"`
+	// Number of warp clients.
+	Clients int `json:"clients"`
 	// Numbers of hosts
 	Hosts int `json:"hosts"`
 	// Populated if requests are all of same object size.
@@ -184,6 +186,7 @@ func Aggregate(o bench.Operations, dFn SegmentDurFn, skipDur time.Duration) Aggr
 			a.Throughput.Segmented.fill(segs, total)
 			a.ObjectsPerOperation = ops.FirstObjPerOp()
 			a.Concurrency = ops.Threads()
+			a.Clients = ops.Clients()
 			a.Hosts = ops.Hosts()
 
 			if !ops.MultipleSizes() {

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -800,6 +800,18 @@ func (o Operations) Hosts() int {
 	return len(endpoints)
 }
 
+// Clients returns the number of clients.
+func (o Operations) Clients() int {
+	if len(o) == 0 {
+		return 0
+	}
+	clients := make(map[string]struct{}, 10)
+	for _, op := range o {
+		clients[op.ClientID] = struct{}{}
+	}
+	return len(clients)
+}
+
 // Endpoints returns the endpoints as a sorted slice.
 func (o Operations) Endpoints() []string {
 	if len(o) == 0 {


### PR DESCRIPTION
Example output:

```
Operation: PUT (3558914). Concurrency: 512. Hosts: 4. Warp Instances: 4.

....
```