### PR TITLE
Fix filtered time function

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -176,7 +176,10 @@ func (s *Server) handleAggregated(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if s.agrr == nil || s.aggrDur != segmentDur {
-		aggr := aggregate.Aggregate(s.ops, durFn, 0)
+		aggr := aggregate.Aggregate(s.ops, aggregate.Options{
+			DurFunc: durFn,
+			SkipDur: 0,
+		})
 		s.agrr = &aggr
 		s.aggrDur = segmentDur
 	}


### PR DESCRIPTION
When a pre-analysis segmentation is added like `--analyze.host=xyz` don't expect all threads to have completed one operation at each end.

Since we don't have the operations any more, there may be significant gaps.

Instead use the simpler time function for these.