### PR TITLE
Set a default concurrency of 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ This will run the benchmark for up to 5 minutes and print the results.
 
 # Benchmarks
 
-All benchmarks operate concurrently. 
-By default the processor determines the number of operations that will be running concurrently. 
+All benchmarks operate concurrently. By default, 20 operations will run concurrently.
 This can however also be tweaked using the `--concurrent` parameter.
 
 Tweaking concurrency can have an impact on performance, especially if latency to the server is tested. 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -20,7 +20,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/minio/cli"
 	"github.com/minio/minio/pkg/console"
@@ -194,7 +193,7 @@ var ioFlags = []cli.Flag{
 	},
 	cli.IntFlag{
 		Name:  "concurrent",
-		Value: runtime.GOMAXPROCS(0),
+		Value: 20,
 		Usage: "Run this many concurrent operations",
 	},
 	cli.BoolFlag{


### PR DESCRIPTION
Let's make the benchmark machine independent by default.