### PR TITLE
Mixed analysis: Disregard errors from totals

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -266,7 +266,7 @@ func printAnalysis(ctx *cli.Context, o bench.Operations) {
 	})
 	if wrSegs != nil {
 		for _, ops := range aggr.Operations {
-			writeSegs(ctx, wrSegs, o.FilterByOp(ops.Type), aggr.Mixed, details)
+			writeSegs(ctx, wrSegs, o.FilterByOp(ops.Type), aggr.Mixed || prefiltered, details)
 		}
 	}
 
@@ -385,7 +385,7 @@ func writeSegs(ctx *cli.Context, wrSegs io.Writer, ops bench.Operations, allThre
 	segs := ops.Segment(bench.SegmentOptions{
 		From:           time.Time{},
 		PerSegDuration: analysisDur(ctx, totalDur),
-		AllThreads:     allThreads,
+		AllThreads:     allThreads && !ops.HasError(),
 	})
 
 	segs.SortByTime()
@@ -400,12 +400,12 @@ func writeSegs(ctx *cli.Context, wrSegs io.Writer, ops bench.Operations, allThre
 			segs := ops.Segment(bench.SegmentOptions{
 				From:           time.Time{},
 				PerSegDuration: analysisDur(ctx, totalDur),
-				AllThreads:     allThreads,
+				AllThreads:     false,
 			})
 			if len(segs) <= 1 {
 				continue
 			}
-			totals := ops.Total(allThreads)
+			totals := ops.Total(false)
 			if totals.TotalBytes > 0 {
 				segs.SortByThroughput()
 			} else {

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -195,11 +195,12 @@ func printMixedOpAnalysis(ctx *cli.Context, aggr aggregate.Aggregated, details b
 
 			for ep, totals := range eps {
 				console.SetColor("Print", color.New(color.FgWhite))
-				console.Print(" * ", ep, ": Avg: ", totals.StringDetails(details), "\n")
+				console.Print(" * ", ep, ": Avg: ", totals.StringDetails(details), ".")
 				if totals.Errors > 0 {
 					console.SetColor("Print", color.New(color.FgHiRed))
-					console.Println("Errors:", totals.Errors)
+					console.Print(" Errors: ", totals.Errors)
 				}
+				console.Println("")
 			}
 		}
 
@@ -212,6 +213,10 @@ func printMixedOpAnalysis(ctx *cli.Context, aggr aggregate.Aggregated, details b
 	dur := time.Duration(aggr.MixedServerStats.MeasureDurationMillis) * time.Millisecond
 	dur = dur.Round(time.Second)
 	console.Printf("\nCluster Total: %v over %v.\n", aggr.MixedServerStats.StringDetails(details), dur)
+	if aggr.MixedServerStats.Errors > 0 {
+		console.SetColor("Print", color.New(color.FgHiRed))
+		console.Print("Total Errors:", aggr.MixedServerStats.Errors, ".\n")
+	}
 	console.SetColor("Print", color.New(color.FgWhite))
 	if eps := aggr.MixedThroughputByHost; len(eps) > 1 && details {
 		for ep, ops := range eps {

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -209,7 +209,9 @@ func printMixedOpAnalysis(ctx *cli.Context, aggr aggregate.Aggregated, details b
 		}
 	}
 	console.SetColor("Print", color.New(color.FgHiWhite))
-	console.Println("\nCluster Total:", aggr.MixedServerStats.StringDetails(details))
+	dur := time.Duration(aggr.MixedServerStats.MeasureDurationMillis) * time.Millisecond
+	dur = dur.Round(time.Second)
+	console.Printf("\nCluster Total: %v over %v.\n", aggr.MixedServerStats.StringDetails(details), dur)
 	console.SetColor("Print", color.New(color.FgWhite))
 	if eps := aggr.MixedThroughputByHost; len(eps) > 1 && details {
 		for ep, ops := range eps {

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -97,8 +97,8 @@ func Aggregate(o bench.Operations, opts Options) Aggregated {
 		a.Mixed = true
 		a.Type = "mixed"
 		var ops bench.Operations
-		hasErrs := o.HasError()
-		if !hasErrs {
+		errs := o.FilterErrors()
+		if len(errs) == 0 {
 			start, end := o.ActiveTimeRange(!opts.Prefiltered)
 			start.Add(opts.SkipDur)
 			o = o.FilterInsideRange(start, end)
@@ -113,6 +113,7 @@ func Aggregate(o bench.Operations, opts Options) Aggregated {
 		}
 
 		total := ops.Total(false)
+		total.Errors = len(errs)
 		a.MixedServerStats = &Throughput{}
 		a.MixedServerStats.fill(total)
 
@@ -142,8 +143,8 @@ func Aggregate(o bench.Operations, opts Options) Aggregated {
 				ops := ops.FilterByEndpoint(ep)
 				t := Throughput{}
 				t.fill(ops.Total(false))
-				if hasErrs {
-					errs := o.FilterErrors().FilterByEndpoint(ep)
+				if len(errs) > 0 {
+					errs := errs.FilterByEndpoint(ep)
 					t.Errors = len(errs)
 				}
 				mu.Lock()

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -103,6 +103,11 @@ func Aggregate(o bench.Operations, opts Options) Aggregated {
 			o = o.FilterInsideRange(start, end)
 			ops = o
 		} else {
+			if opts.SkipDur > 0 {
+				start, end := o.TimeRange()
+				start.Add(opts.SkipDur)
+				o = o.FilterInsideRange(start, end)
+			}
 			ops = o.FilterSuccessful()
 		}
 

--- a/pkg/aggregate/requests.go
+++ b/pkg/aggregate/requests.go
@@ -194,7 +194,7 @@ func RequestAnalysisHostsSingleSized(o bench.Operations) map[string]SingleSizedR
 func RequestAnalysisMultiSized(o bench.Operations, allThreads bool) *MultiSizedRequests {
 	var res MultiSizedRequests
 	// Single type, require one operation per thread.
-	start, end := o.ActiveTimeRange(false)
+	start, end := o.ActiveTimeRange(allThreads)
 	active := o.FilterInsideRange(start, end)
 
 	res.Requests = len(active)

--- a/pkg/aggregate/throughput.go
+++ b/pkg/aggregate/throughput.go
@@ -61,8 +61,12 @@ func (t Throughput) StringDetails(details bool) string {
 	if t.AverageBPS > 0 {
 		speed = fmt.Sprintf("%.02f MiB/s, ", t.AverageBPS/(1<<20))
 	}
-	return fmt.Sprintf("%s%.02f obj/s",
-		speed, t.AverageOPS)
+	errs := ""
+	if t.Errors > 0 {
+		errs = fmt.Sprintf(", %d errors", t.Errors)
+	}
+	return fmt.Sprintf("%s%.02f obj/s%s",
+		speed, t.AverageOPS, errs)
 }
 
 func (t *Throughput) fill(total bench.Segment) {

--- a/pkg/aggregate/throughput.go
+++ b/pkg/aggregate/throughput.go
@@ -33,6 +33,8 @@ type Throughput struct {
 	MeasureDurationMillis int `json:"measure_duration_millis"`
 	// Start time of the measurement.
 	StartTime time.Time `json:"start_time"`
+	// End time of the measurement.
+	EndTime time.Time `json:"end_time"`
 	// Average bytes per second. Can be 0.
 	AverageBPS float64 `json:"average_bps"`
 	// Average operations per second.
@@ -69,6 +71,7 @@ func (t *Throughput) fill(total bench.Segment) {
 		Operations:            total.FullOps,
 		MeasureDurationMillis: durToMillis(total.EndsBefore.Sub(total.Start)),
 		StartTime:             total.Start,
+		EndTime:               total.EndsBefore,
 		AverageBPS:            math.Round(mib*(1<<20)*10) / 10,
 		AverageOPS:            math.Round(objs*100) / 100,
 		Errors:                total.Errors,

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -431,6 +431,19 @@ func (o Operations) IsMixed() bool {
 	return o.isMixed(o.OpTypes())
 }
 
+// HasError returns whether one or more operations failed.
+func (o Operations) HasError() bool {
+	if len(o) == 0 {
+		return false
+	}
+	for _, op := range o {
+		if len(op.Err) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // isMixed returns true if operation types are overlapping.
 func (o Operations) isMixed(types []string) bool {
 	if len(types) <= 1 {
@@ -843,12 +856,25 @@ func (o Operations) Errors() []string {
 	return errs
 }
 
-// FilterSuccessful returns the errors found.
+// FilterSuccessful returns the successful requests.
 func (o Operations) FilterSuccessful() Operations {
 	if len(o) == 0 {
 		return nil
 	}
-	ok := make(Operations, 0, len(o))
+	failed := 0
+	for _, op := range o {
+		if len(op.Err) > 0 {
+			failed++
+		}
+	}
+	if failed == 0 {
+		return o
+	}
+	if failed == len(o) {
+		return nil
+	}
+
+	ok := make(Operations, 0, len(o)-failed)
 	for _, op := range o {
 		if len(op.Err) == 0 {
 			ok = append(ok, op)


### PR DESCRIPTION
Disregard errors from mixed analysis and don't require all threads to have completed for the mixed totals.

This could make totals and partial results diverge quite a bit and makes the total operations not match up.

For mixed operations time filter operations consistently by doing only one time segmentation and use that for individual ops as well.

If there are errors don't do time filtering, so we don't hide them.

Before:

```
1354872 operations loaded... Done!
Mixed operations.
Operation: GET, 64%, Concurrency: 96, Duration: 10m0s.
Errors: 44
 * Throughput: 49.27 MiB/s, 1128.98 obj/s

Operation: PUT, 64%, Concurrency: 96, Duration: 10m0s.
Errors: 19
 * Throughput: 49.39 MiB/s, 1128.98 obj/s

Cluster Total: 94.71 MiB/s, 2169.14 obj/s
```

After:

```
1354872 operations loaded... Done!
Mixed operations.
Operation: GET, 50%, Concurrency: 96, Duration: 10m0s.
Errors: 44
 * Throughput: 49.27 MiB/s, 1128.98 obj/s

Operation: PUT, 50%, Concurrency: 96, Duration: 10m0s.
Errors: 19
 * Throughput: 49.39 MiB/s, 1128.98 obj/s

Cluster Total: 98.66 MiB/s, 2257.96 obj/s over 10m0s.
```