### PR TITLE
Fix crash when there isn't enough data

### DIFF
--- a/pkg/bench/analyze.go
+++ b/pkg/bench/analyze.go
@@ -139,7 +139,7 @@ func (o Operations) OpThroughput() Throughput {
 func (o Operations) Segment(so SegmentOptions) Segments {
 	o.SortByStartTime()
 	if so.PerSegDuration <= 0 {
-		panic("internal error: so.PerSegDuration <= 0")
+		return nil
 	}
 	start, end := o.ActiveTimeRange(so.AllThreads)
 	if start.After(so.From) {


### PR DESCRIPTION
When there isn't enough data for a full segment the segment duration will be 0 causing a crash.

Before:
```
λ go build && warp analyze warp-mixed-2021-01-04[011541]-58G4.csv.zst
1481 operations loaded... Done!
panic: internal error: so.PerSegDuration <= 0

goroutine 77 [running]:
github.com/minio/warp/pkg/bench.Operations.Segment(0xc00038e000, 0x0, 0xe9, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        e:/gopath/src/github.com/minio/warp/pkg/bench/analyze.go:142 +0x935
github.com/minio/warp/pkg/aggregate.Aggregate.func2(0xc0001800a0, 0x4, 0x5, 0xc0002e2d80, 0x4, 0x4, 0xc001bba030, 0xc0004027a0, 0xc0004027c0, 0x2)
        e:/gopath/src/github.com/minio/warp/pkg/aggregate/aggregate.go:191 +0x546
created by github.com/minio/warp/pkg/aggregate.Aggregate
        e:/gopath/src/github.com/minio/warp/pkg/aggregate/aggregate.go:164 +0x790
```

After:
```
λ go build && warp analyze warp-mixed-2021-01-04[011541]-58G4.csv.zst
1481 operations loaded... Done!
Mixed operations.
Operation: DELETE, 1%, Concurrency: 96, Duration: 53s.
 * Throughput: 0.58 obj/s

Operation: GET, 52%, Concurrency: 100, Duration: 54s.
 * Throughput: 114.06 MiB/s, 2.28 obj/s

Operation: PUT, 0%, Concurrency: 0, Duration: 0s.
Skipping PUT too few samples.

Operation: STAT, 40%, Concurrency: 99, Duration: 58s.
 * Throughput: 1.64 obj/s

Cluster Total: 106.26 MiB/s, 3.99 obj/s over 58s.
```

Still too little data for meaningful output, but works.

Fixes #156