### PR TITLE
Add first access analysis

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -442,18 +442,35 @@ func printRequestAnalysis(ctx *cli.Context, ops aggregate.Operation, details boo
 			return
 		}
 
-		console.Println(
-			" * Avg:", time.Duration(reqs.DurAvgMillis)*time.Millisecond,
-			"50%:", time.Duration(reqs.DurMedianMillis)*time.Millisecond,
-			"90%:", time.Duration(reqs.Dur90Millis)*time.Millisecond,
-			"99%:", time.Duration(reqs.Dur99Millis)*time.Millisecond,
-			"Fastest:", time.Duration(reqs.FastestMillis)*time.Millisecond,
-			"Slowest:", time.Duration(reqs.SlowestMillis)*time.Millisecond,
-		)
+		console.Print(
+			" * Avg: ", time.Duration(reqs.DurAvgMillis)*time.Millisecond,
+			", 50%: ", time.Duration(reqs.DurMedianMillis)*time.Millisecond,
+			", 90%: ", time.Duration(reqs.Dur90Millis)*time.Millisecond,
+			", 99%: ", time.Duration(reqs.Dur99Millis)*time.Millisecond,
+			", Fastest: ", time.Duration(reqs.FastestMillis)*time.Millisecond,
+			", Slowest: ", time.Duration(reqs.SlowestMillis)*time.Millisecond,
+			"\n")
 
 		if reqs.FirstByte != nil {
 			console.Println(" * First Byte:", reqs.FirstByte)
 		}
+
+		if reqs.FirstAccess != nil {
+			reqs := reqs.FirstAccess
+			console.Print(
+				" * First Access: Avg: ", time.Duration(reqs.DurAvgMillis)*time.Millisecond,
+				", 50%: ", time.Duration(reqs.DurMedianMillis)*time.Millisecond,
+				", 90%: ", time.Duration(reqs.Dur90Millis)*time.Millisecond,
+				", 99%: ", time.Duration(reqs.Dur99Millis)*time.Millisecond,
+				", Fastest: ", time.Duration(reqs.FastestMillis)*time.Millisecond,
+				", Slowest: ", time.Duration(reqs.SlowestMillis)*time.Millisecond,
+				"\n")
+			if reqs.FirstByte != nil {
+				console.Print(" * First Access TTFB: ", reqs.FirstByte)
+			}
+			console.Println("")
+		}
+
 		if eps := reqs.ByHost; len(eps) > 1 && details {
 			console.SetColor("Print", color.New(color.FgHiWhite))
 			console.Println("\nRequests by host:")
@@ -504,9 +521,26 @@ func printRequestAnalysis(ctx *cli.Context, ops aggregate.Operation, details boo
 			", Fastest: ", bench.Throughput(s.BpsFastest),
 			", Slowest: ", bench.Throughput(s.BpsSlowest),
 			"\n")
+
 		if s.FirstByte != nil {
 			console.Println(" * First Byte:", s.FirstByte)
 		}
+
+		if s.FirstAccess != nil {
+			s := s.FirstAccess
+			console.Print(""+
+				" * First Access: Average: ", bench.Throughput(s.BpsAverage),
+				", 50%: ", bench.Throughput(s.BpsMedian),
+				", 90%: ", bench.Throughput(s.Bps90),
+				", 99%: ", bench.Throughput(s.Bps99),
+				", Fastest: ", bench.Throughput(s.BpsFastest),
+				", Slowest: ", bench.Throughput(s.BpsSlowest),
+				"\n")
+			if s.FirstByte != nil {
+				console.Print(" * First Access TTFB: ", s.FirstByte, "\n")
+			}
+		}
+
 	}
 	if eps := reqs.ByHost; len(eps) > 1 && details {
 		console.SetColor("Print", color.New(color.FgHiWhite))

--- a/pkg/aggregate/ttfb.go
+++ b/pkg/aggregate/ttfb.go
@@ -37,7 +37,7 @@ func (t TTFB) String() string {
 	if t.AverageMillis == 0 {
 		return ""
 	}
-	return fmt.Sprintf("Average: %v, Median: %v, Best: %v, Worst: %v",
+	return fmt.Sprintf("Avg: %v, Median: %v, Best: %v, Worst: %v",
 		time.Duration(t.AverageMillis)*time.Millisecond,
 		time.Duration(t.MedianMillis)*time.Millisecond,
 		time.Duration(t.FastestMillis)*time.Millisecond,


### PR DESCRIPTION
This will print out the request stats for the first object access in case the same object is accessed more than once (typically in GET operations)

Only shown when details are requested.


Example output single sized objects:

```
Requests considered: 4737:
 * Avg: 5.323s, 50%: 4.499s, 90%: 9.432s, 99%: 15.234s, Fastest: 499ms, Slowest: 23.375s
 * First Byte: Avg: 747ms, Median: 458ms, Best: 17ms, Worst: 7.613s
 * First Access:
         - Avg: 5.561s, 50%: 4.762s, 90%: 9.58s, 99%: 15.441s, Fastest: 957ms, Slowest: 23.375s
         - TTFB: Avg: 984ms, Median: 662ms, Best: 59ms, Worst: 7.613s
```

Multi sized:
```
Requests considered: 77861. Multiple sizes, average 1833115 bytes:

Request size 1 B -> 10 KiB. Requests - 10811:
 * Throughput: Average: 1534.1KiB/s, 50%: 1571.1KiB/s, 90%: 163.3KiB/s, 99%: 6.6KiB/s, Fastest: 9.7MiB/s, Slowest: 1124.8B/s
 * First Byte: Avg: 3ms, Median: 2ms, Best: 1ms, Worst: 39ms
 * First Access: Average: 4.6MiB/s, 50%: 4.5MiB/s, 90%: 979.4KiB/s, 99%: 67.4KiB/s, Fastest: 9.7MiB/s, Slowest: 8.8KiB/s
 * First Access TTFB: Avg: 1ms, Median: 1ms, Best: 1ms, Worst: 2ms

Request size 10KiB -> 1MiB. Requests - 38069:
 * Throughput: Average: 73.5MiB/s, 50%: 66.4MiB/s, 90%: 27.0MiB/s, 99%: 13.6MiB/s, Fastest: 397.6MiB/s, Slowest: 3.1MiB/s
 * First Byte: Avg: 3ms, Median: 2ms, Best: 1ms, Worst: 41ms
 * First Access: Average: 152.4MiB/s, 50%: 138.3MiB/s, 90%: 69.8MiB/s, 99%: 42.5MiB/s, Fastest: 397.6MiB/s, Slowest: 39.1MiB/s
 * First Access TTFB: Avg: 1ms, Median: 1ms, Best: 1ms, Worst: 3ms

Request size 1MiB -> 10MiB. Requests - 32992:
 * Throughput: Average: 162.1MiB/s, 50%: 159.4MiB/s, 90%: 114.3MiB/s, 99%: 80.3MiB/s, Fastest: 505.4MiB/s, Slowest: 22.4MiB/s
 * First Byte: Avg: 3ms, Median: 2ms, Best: 1ms, Worst: 40ms
 * First Access: Average: 273.0MiB/s, 50%: 265.4MiB/s, 90%: 217.7MiB/s, 99%: 189.8MiB/s, Fastest: 505.4MiB/s, Slowest: 166.7MiB/s
 * First Access TTFB: Avg: 2ms, Median: 2ms, Best: 1ms, Worst: 15ms
```