### PR TITLE
add --resolve-host flag to force DNS resolution to explode multiple A/AAAA records

### DIFF
--- a/cli/benchserver.go
+++ b/cli/benchserver.go
@@ -92,7 +92,7 @@ func runServerBenchmark(ctx *cli.Context, b bench.Benchmark) (bool, error) {
 		return false, nil
 	}
 
-	conns := newConnections(parseHosts(ctx.String("warp-client")))
+	conns := newConnections(parseHosts(ctx.String("warp-client"), false))
 	if len(conns.hosts) == 0 {
 		return true, errors.New("no hosts")
 	}

--- a/cli/client.go
+++ b/cli/client.go
@@ -51,7 +51,7 @@ const (
 )
 
 func newClient(ctx *cli.Context) func() (cl *minio.Client, done func()) {
-	hosts := parseHosts(ctx.String("host"))
+	hosts := parseHosts(ctx.String("host"), ctx.Bool("resolve-host"))
 	switch len(hosts) {
 	case 0:
 		fatalIf(probe.NewError(errors.New("no host defined")), "Unable to create MinIO client")
@@ -214,7 +214,7 @@ func clientTransport(ctx *cli.Context) http.RoundTripper {
 }
 
 // parseHosts will parse the host parameter given.
-func parseHosts(h string) []string {
+func parseHosts(h string, resolveDNS bool) []string {
 	hosts := strings.Split(h, ",")
 	var dst []string
 	for _, host := range hosts {
@@ -232,7 +232,31 @@ func parseHosts(h string) []string {
 			dst = append(dst, strings.Join(lbls, ""))
 		}
 	}
-	return dst
+
+	if !resolveDNS {
+		return dst
+	}
+
+	var resolved []string
+	for _, hostport := range dst {
+		host, port, _ := net.SplitHostPort(hostport)
+		if host == "" {
+			host = hostport
+		}
+		ips, err := net.LookupIP(host)
+		if err != nil {
+			fatalIf(probe.NewError(err), "Could not get IPs for "+hostport)
+			log.Fatal(err.Error())
+		}
+		for _, ip := range ips {
+			if port == "" {
+				resolved = append(resolved, ip.String())
+			} else {
+				resolved = append(resolved, ip.String()+":"+port)
+			}
+		}
+	}
+	return resolved
 }
 
 // mustGetSystemCertPool - return system CAs or empty pool in case of error (or windows)
@@ -248,7 +272,7 @@ func mustGetSystemCertPool() *x509.CertPool {
 }
 
 func newAdminClient(ctx *cli.Context) *madmin.AdminClient {
-	hosts := parseHosts(ctx.String("host"))
+	hosts := parseHosts(ctx.String("host"), ctx.Bool("resolve-host"))
 	if len(hosts) == 0 {
 		fatalIf(probe.NewError(errors.New("no host defined")), "Unable to create MinIO admin client")
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -186,6 +186,11 @@ var ioFlags = []cli.Flag{
 		Value: string(hostSelectTypeWeighed),
 		Usage: fmt.Sprintf("Host selection algorithm. Can be %q or %q", hostSelectTypeWeighed, hostSelectTypeRoundrobin),
 	},
+	cli.BoolFlag{
+		Name:   "resolve-host",
+		Usage:  "Resolve the host(s) ip(s) (including multiple A/AAAA records). This can break SSL certificates, use --insecure if so",
+		Hidden: true,
+	},
 	cli.IntFlag{
 		Name:  "concurrent",
 		Value: 20,


### PR DESCRIPTION
when s3.xxxx.org has multiple A/AAAA records, I would want warp to explode it to all the IPs without having to specifying all of them by hand.