### PR TITLE
Add last request access stats

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -463,7 +463,7 @@ func printRequestAnalysis(ctx *cli.Context, ops aggregate.Operation, details boo
 			console.Println(" * TTFB:", reqs.FirstByte)
 		}
 
-		if reqs.FirstAccess != nil {
+		if details && reqs.FirstAccess != nil {
 			reqs := reqs.FirstAccess
 			console.Print(
 				" * First Access: Avg: ", time.Duration(reqs.DurAvgMillis)*time.Millisecond,
@@ -476,7 +476,20 @@ func printRequestAnalysis(ctx *cli.Context, ops aggregate.Operation, details boo
 			if reqs.FirstByte != nil {
 				console.Print(" * First Access TTFB: ", reqs.FirstByte)
 			}
-			console.Println("")
+		}
+		if details && reqs.LastAccess != nil {
+			reqs := reqs.LastAccess
+			console.Print(
+				" * Last Access: Avg: ", time.Duration(reqs.DurAvgMillis)*time.Millisecond,
+				", 50%: ", time.Duration(reqs.DurMedianMillis)*time.Millisecond,
+				", 90%: ", time.Duration(reqs.Dur90Millis)*time.Millisecond,
+				", 99%: ", time.Duration(reqs.Dur99Millis)*time.Millisecond,
+				", Fastest: ", time.Duration(reqs.FastestMillis)*time.Millisecond,
+				", Slowest: ", time.Duration(reqs.SlowestMillis)*time.Millisecond,
+				"\n")
+			if reqs.FirstByte != nil {
+				console.Print(" * Last Access TTFB: ", reqs.FirstByte)
+			}
 		}
 
 		if eps := reqs.ByHost; len(eps) > 1 && details {

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -922,9 +922,30 @@ func (o Operations) FilterFirst() Operations {
 	if len(o) == 0 {
 		return nil
 	}
+	o.SortByStartTime()
 	ok := make(Operations, 0, 1000)
 	seen := make(map[string]struct{}, len(o))
 	for _, op := range o {
+		if _, ok := seen[op.File]; ok {
+			continue
+		}
+		seen[op.File] = struct{}{}
+		ok = append(ok, op)
+	}
+
+	return ok
+}
+
+// FilterLast returns the last operation on any file.
+func (o Operations) FilterLast() Operations {
+	if len(o) == 0 {
+		return nil
+	}
+	o.SortByStartTime()
+	ok := make(Operations, 0, 1000)
+	seen := make(map[string]struct{}, len(o))
+	for i := len(o) - 1; i >= 0; i-- {
+		op := o[i]
 		if _, ok := seen[op.File]; ok {
 			continue
 		}


### PR DESCRIPTION
Similar to stats for first access to an object, provide last object access stats, but only print them in detailed mode.