### PR TITLE
Add versioned listing

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -161,9 +161,9 @@ func printMixedOpAnalysis(ctx *cli.Context, aggr aggregate.Aggregated, details b
 		}
 		duration := ops.EndTime.Sub(ops.StartTime).Truncate(time.Second)
 		if !details {
-			console.Printf("Operation: %v, %d%%, Concurrency: %d, Duration: %v.\n", ops.Type, int(pct+0.5), ops.Concurrency, duration)
+			console.Printf("Operation: %v, %d%%, Concurrency: %d, Ran %v.\n", ops.Type, int(pct+0.5), ops.Concurrency, duration)
 		} else {
-			console.Printf("Operation: %v - total: %v, %.01f%%, Concurrency: %d, Duration: %v, starting %v\n", ops.Type, ops.Throughput.Operations, pct, ops.Concurrency, duration, ops.StartTime.Truncate(time.Millisecond))
+			console.Printf("Operation: %v - total: %v, %.01f%%, Concurrency: %d, Ran %v, starting %v\n", ops.Type, ops.Throughput.Operations, pct, ops.Concurrency, duration, ops.StartTime.Truncate(time.Millisecond))
 		}
 		console.SetColor("Print", color.New(color.FgWhite))
 
@@ -301,15 +301,16 @@ func printAnalysis(ctx *cli.Context, o bench.Operations) {
 		if ops.Clients > 1 {
 			hostsString = fmt.Sprintf("%s Warp Instances: %d.", hostsString, ops.Clients)
 		}
+		ran := ops.EndTime.Sub(ops.StartTime).Truncate(time.Second)
 		if opo > 1 {
 			if details {
-				console.Printf("Operation: %v (%d). Objects per operation: %d. Concurrency: %d.%s\n", typ, ops.N, opo, ops.Concurrency, hostsString)
+				console.Printf("Operation: %v (%d). Ran %v. Objects per operation: %d. Concurrency: %d.%s\n", typ, ops.N, ran, opo, ops.Concurrency, hostsString)
 			} else {
 				console.Printf("Operation: %v\n", typ)
 			}
 		} else {
 			if details {
-				console.Printf("Operation: %v (%d). Concurrency: %d.%s\n", typ, ops.N, ops.Concurrency, hostsString)
+				console.Printf("Operation: %v (%d). Ran %v. Concurrency: %d.%s\n", typ, ops.N, ran, ops.Concurrency, hostsString)
 			} else {
 				console.Printf("Operation: %v\n", typ)
 			}
@@ -474,7 +475,7 @@ func printRequestAnalysis(ctx *cli.Context, ops aggregate.Operation, details boo
 				", Slowest: ", time.Duration(reqs.SlowestMillis)*time.Millisecond,
 				"\n")
 			if reqs.FirstByte != nil {
-				console.Print(" * First Access TTFB: ", reqs.FirstByte)
+				console.Print(" * First Access TTFB: ", reqs.FirstByte, "\n")
 			}
 		}
 		if details && reqs.LastAccess != nil {
@@ -488,7 +489,7 @@ func printRequestAnalysis(ctx *cli.Context, ops aggregate.Operation, details boo
 				", Slowest: ", time.Duration(reqs.SlowestMillis)*time.Millisecond,
 				"\n")
 			if reqs.FirstByte != nil {
-				console.Print(" * Last Access TTFB: ", reqs.FirstByte)
+				console.Print(" * Last Access TTFB: ", reqs.FirstByte, "\n")
 			}
 		}
 

--- a/cli/list.go
+++ b/cli/list.go
@@ -30,6 +30,11 @@ var (
 			Value: 10000,
 			Usage: "Number of objects to upload. Rounded to have equal concurrent objects.",
 		},
+		cli.IntFlag{
+			Name:  "versions",
+			Value: 1,
+			Usage: "Number of versions to upload. If more than 1, versioned listing will be benchmarked",
+		},
 		cli.StringFlag{
 			Name:  "obj.size",
 			Value: "1KB",
@@ -74,6 +79,7 @@ func mainList(ctx *cli.Context) error {
 			Location:    "",
 			PutOpts:     putOpts(ctx),
 		},
+		Versions:      ctx.Int("versions"),
 		Metadata:      ctx.Bool("metadata"),
 		CreateObjects: ctx.Int("objects"),
 		NoPrefix:      ctx.Bool("noprefix"),
@@ -84,6 +90,9 @@ func mainList(ctx *cli.Context) error {
 func checkListSyntax(ctx *cli.Context) {
 	if ctx.NArg() > 0 {
 		console.Fatal("Command takes no arguments")
+	}
+	if ctx.Int("versions") < 1 {
+		console.Fatal("At least one version must be tested")
 	}
 
 	checkAnalyze(ctx)

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
-	"sort"
 	"sync"
 	"time"
 
@@ -78,8 +77,8 @@ func (m *MixedDistribution) Generate(allocObjs int) error {
 		}
 	}
 	m.rng = rand.New(rand.NewSource(0xabad1dea))
-	sort.Slice(m.ops, func(i, j int) bool {
-		return m.rng.Int63()&1 == 0
+	m.rng.Shuffle(len(m.ops), func(i, j int) {
+		m.ops[i], m.ops[j] = m.ops[j], m.ops[i]
 	})
 	return nil
 }

--- a/pkg/bench/retention.go
+++ b/pkg/bench/retention.go
@@ -47,13 +47,13 @@ func (g *Retention) Prepare(ctx context.Context) error {
 		return err
 	}
 	cl, done := g.Client()
-	defer done()
 	if !g.Versioned {
 		err := cl.EnableVersioning(ctx, g.Bucket)
 		if err != nil {
 			return err
 		}
 		g.Versioned = true
+		done()
 	}
 
 	src := g.Source()


### PR DESCRIPTION
If versioned listing should be tested, it is possible by setting `--versions=n` (default 1),
which will add multiple versions of each object and use `ListObjectVersions` for listing.

Minor tweaks to analysis output.