### PR TITLE
Added support for passing --objects in put operation with benchmarking

### DIFF
--- a/cli/put.go
+++ b/cli/put.go
@@ -26,6 +26,11 @@ import (
 
 var (
 	putFlags = []cli.Flag{
+		cli.IntFlag{
+			Name:  "objects",
+			Value: 0,
+			Usage: "Number of objects to upload.",
+		},
 		cli.StringFlag{
 			Name:  "obj.size",
 			Value: "10MiB",
@@ -66,6 +71,7 @@ func mainPut(ctx *cli.Context) error {
 			Location:    "",
 			PutOpts:     putOpts(ctx),
 		},
+		CreateObjects: ctx.Int("objects"),
 	}
 	return runBench(ctx, &b)
 }


### PR DESCRIPTION
Summary:
Added support for passing --objects in put operation with benchmarking

Description:
With the code changes done, the put method can upload a specific number of objects with benchmarking.
Following are the scenarios for passing --objects:
1. when "--objects <object_count>" is passed, the specified number of objects will be uploaded to the bucket
2. when "--objects <object_count>" is not passed, benchmarking will happen till the default duration