### PR TITLE
Helm chart improvement

### DIFF
--- a/k8s/helm-chart/templates/job.yaml
+++ b/k8s/helm-chart/templates/job.yaml
@@ -12,7 +12,12 @@ spec:
       - name: {{ include "warp.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: [ "{{ .Values.warpConfiguration.operationToBenchmark }}", "--warp-client", "warp-{0...{{ sub .Values.replicaCount 1 }}}.warp.{{ .Release.Namespace }}.svc.cluster.local", "--concurrent", "{{ .Values.warpConfiguration.concurrentOperations }}", "--obj.size", "{{ .Values.warpConfiguration.objectSize }}", "--objects", "{{ .Values.warpConfiguration.objectCount }}", "--duration", "{{ .Values.warpConfiguration.duration }}", "--bucket", "{{ .Values.warpConfiguration.bucket }}" ]
+        args:
+          - "{{ .Values.warpConfiguration.operationToBenchmark }}"
+          - "--warp-client=warp-{0...{{ sub .Values.replicaCount 1 }}}.warp.{{ .Release.Namespace }}"
+        {{- range $k, $v := .Values.warpJobArgs }}
+          - --{{ $k }}={{ $v }}
+        {{- end }}
         env:
           - name: WARP_HOST
             value: {{ .Values.warpConfiguration.s3ServerURL | quote }}

--- a/k8s/helm-chart/templates/job.yaml
+++ b/k8s/helm-chart/templates/job.yaml
@@ -12,7 +12,7 @@ spec:
       - name: {{ include "warp.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: [ "{{ .Values.warpConfiguration.operationToBenchmark }}", "--warp-client", "warp-{0...{{ sub .Values.replicaCount 1 }}}.warp.default.svc.cluster.local", "--concurrent", "{{ .Values.warpConfiguration.concurrentOperations }}", "--obj.size", "{{ .Values.warpConfiguration.objectSize }}", "--objects", "{{ .Values.warpConfiguration.objectCount }}", "--duration", "{{ .Values.warpConfiguration.duration }}", "--bucket", "{{ .Values.warpConfiguration.bucket }}" ]
+        args: [ "{{ .Values.warpConfiguration.operationToBenchmark }}", "--warp-client", "warp-{0...{{ sub .Values.replicaCount 1 }}}.warp.{{ .Release.Namespace }}.svc.cluster.local", "--concurrent", "{{ .Values.warpConfiguration.concurrentOperations }}", "--obj.size", "{{ .Values.warpConfiguration.objectSize }}", "--objects", "{{ .Values.warpConfiguration.objectCount }}", "--duration", "{{ .Values.warpConfiguration.duration }}", "--bucket", "{{ .Values.warpConfiguration.bucket }}" ]
         env:
           - name: WARP_HOST
             value: {{ .Values.warpConfiguration.s3ServerURL | quote }}

--- a/k8s/helm-chart/templates/job.yaml
+++ b/k8s/helm-chart/templates/job.yaml
@@ -26,4 +26,7 @@ spec:
             value: {{ .Values.warpConfiguration.s3AccessKey | quote }}
           - name: WARP_SECRET_KEY
             value: {{ .Values.warpConfiguration.s3SecretKey | quote }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
+    {{- end }}
   backoffLimit: 4

--- a/k8s/helm-chart/templates/statefulset.yaml
+++ b/k8s/helm-chart/templates/statefulset.yaml
@@ -26,3 +26,9 @@ spec:
           ports:
             - name: http
               containerPort: 7761
+    {{- if .Values.affinity }}
+      affinity: {{- .Values.affinity | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector: {{- .Values.nodeSelector | toYaml | nindent 8 }}
+    {{- end }}

--- a/k8s/helm-chart/values.yaml
+++ b/k8s/helm-chart/values.yaml
@@ -26,18 +26,21 @@ warpConfiguration:
   s3SecretKey: "minio123"
   # Operation to be benchmarked (get / put / delete / list / stat / mixed)
   operationToBenchmark: get
+
+warpJobArgs: {}
+  # Full args can be found: https://github.com/minio/warp#usage
   #
   # Number of objects to be used
-  # objectCount: 1000
+  # objects: 1000
   #
   # Object size to be used for benchmarks
-  # objectSize: 10MiB
+  # obj.size: 10MiB
   #
   # Duration for which the benchmark will run
   # duration: 5m0s
   #
   # Number of parallel operations to run during benchmark
-  # concurrentOperations: 10
+  # concurrent: 10
   #
   # By default operations are performed on a bucket called warp-benchmark-bucket.
   # This can be changed using the --bucket parameter. Do however note that the bucket


### PR DESCRIPTION
* use dynamic job args
  * This can help to not limit the args for a job - For example put bench operation doesn't need objects arg and will raise an error if it set
* add missing nodeSelector and affinity in templates
* use release namespace for svc fqdn