### PR TITLE
Add segment average request time to csv

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Vet
+      - name: go vet
         run: go vet ./...
 
-      - name: fmt
+      - name: go fmt
         run: diff <(gofmt -d .) <(printf "")
 
       - name: Lint

--- a/pkg/bench/analyze.go
+++ b/pkg/bench/analyze.go
@@ -47,6 +47,7 @@ type Segment struct {
 	OpsEnded   int       `json:"ops_ended"`
 	Objects    float64   `json:"objects"`
 	Errors     int       `json:"errors"`
+	ReqAvg     float64   `json:"req_avg_ms"` // Average duration of operations ending in segment.
 	Start      time.Time `json:"start"`
 	EndsBefore time.Time `json:"ends_before"`
 }
@@ -189,6 +190,9 @@ func (o Operations) Segment(so SegmentOptions) Segments {
 				break
 			}
 		}
+		if s.OpsEnded > 0 {
+			s.ReqAvg /= float64(s.OpsEnded)
+		}
 		segments = append(segments, s)
 		segStart = segStart.Add(so.PerSegDuration)
 	}
@@ -234,6 +238,7 @@ func (s Segments) CSV(w io.Writer) error {
 		"mb_per_sec",
 		"ops_ended_per_sec",
 		"objs_per_sec",
+		"reqs_ended_avg_ms",
 		"start_time",
 		"end_time",
 	})
@@ -268,6 +273,7 @@ func (s Segment) CSV(w *csv.Writer, idx int) error {
 		fmt.Sprint(mib),
 		fmt.Sprint(ops),
 		fmt.Sprint(objs),
+		fmt.Sprint(s.ReqAvg),
 		fmt.Sprint(s.Start),
 		fmt.Sprint(s.EndsBefore),
 	})

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -235,6 +235,7 @@ func (o Operation) Aggregate(s *Segment) (done bool) {
 		s.OpsEnded++
 		s.ObjsPerOp = o.ObjPerOp
 		s.Objects += float64(o.ObjPerOp)
+		s.ReqAvg += float64(o.End.Sub(o.Start)) / float64(time.Millisecond)
 		return
 	}
 	// Operation partially within segment.
@@ -253,6 +254,7 @@ func (o Operation) Aggregate(s *Segment) (done bool) {
 			s.Errors++
 			return
 		}
+		s.ReqAvg += float64(o.End.Sub(o.Start)) / float64(time.Millisecond)
 	}
 
 	opDur := o.End.Sub(o.Start)


### PR DESCRIPTION
Add average request time for every operation that ended in segment.

Example:
```
index	op	host	duration_s	objects_per_op	bytes	full_ops	partial_ops	ops_started	ops_ended	errors	mb_per_sec	ops_ended_per_sec	objs_per_sec	reqs_ended_avg_ms	start_time	end_time
0	DELETE		5	1	0	1063	3	1065	1064	0	0	212.8	213.0495901475193	19.8231139520677	2022-12-13 18:29:47.171164484 +0530 +0530	2022-12-13 18:29:52.171164484 +0530 +0530
1	DELETE		5	1	0	1063	9	1070	1065	0	0	213	213.27079393205017	19.643081027230057	2022-12-13 18:29:52.171164484 +0530 +0530	2022-12-13 18:29:57.171164484 +0530 +0530
2	DELETE		5	1	0	1044	9	1046	1051	0	0	210.2	209.7154819242158	20.08534205233112	2022-12-13 18:29:57.171164484 +0530 +0530	2022-12-13 18:30:02.171164484 +0530 +0530
3	DELETE		5	1	0	1066	5	1069	1068	0	0	213.6	213.9573178303453	19.66177282771537	2022-12-13 18:30:02.171164484 +0530 +0530	2022-12-13 18:30:07.171164484 +0530 +0530
4	DELETE		5	1	0	1058	6	1061	1061	0	0	212.2	211.97409918718319	19.934280667295006	2022-12-13 18:30:07.171164484 +0530 +0530	2022-12-13 18:30:12.171164484 +0530 +0530
5	DELETE		5	1	0	1052	6	1055	1055	0	0	211	211.08925306238802	19.995692337440758	2022-12-13 18:30:12.171164484 +0530 +0530	2022-12-13 18:30:17.171164484 +0530 +0530
6	DELETE		5	1	0	1049	8	1054	1052	0	0	210.4	210.4996067535266	20.122888835551308	2022-12-13 18:30:17.171164484 +0530 +0530	2022-12-13 18:30:22.171164484 +0530 +0530
7	DELETE		5	1	0	1050	10	1055	1055	0	0	211	211.37156305734698	19.77957469099529	2022-12-13 18:30:22.171164484 +0530 +0530	2022-12-13 18:30:27.171164484 +0530 +0530 
```