### PR TITLE
Separate detailed listings with dashes

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -153,7 +153,11 @@ func printMixedOpAnalysis(ctx *cli.Context, aggr aggregate.Aggregated, details b
 		console.Errorln("No mixed stats")
 	}
 	for _, ops := range aggr.Operations {
-		console.Println("")
+		if details {
+			console.Println("\n----------------------------------------")
+		} else {
+			console.Println("")
+		}
 		console.SetColor("Print", color.New(color.FgHiWhite))
 		pct := 0.0
 		if aggr.MixedServerStats.Operations > 0 {


### PR DESCRIPTION
Fixes #239

Example:

```
warp analyze -analyze.v warp-mixed-2022-12-13[194820]-kPNY.csv.zst
1526625 operations loaded... Done!
Mixed operations.
----------------------------------------
Operation: DELETE - total: 152639, 10.0%, Concurrency: 24, Ran 14m59s, starting 2022-12-13 19:48:23.682 +0530 +0530

Throughput by host:
 * http://minio-site1-db1:9000: Avg: 56.51 obj/s.
 * http://minio-site1-db2:9000: Avg: 57.24 obj/s.
 * http://minio-site1-db3:9000: Avg: 55.89 obj/s.

Requests considered: 152640:
 * Avg: 27ms, 50%: 26ms, 90%: 35ms, 99%: 47ms, Fastest: 10ms, Slowest: 276ms

Requests by host:
 * http://minio-site1-db1:9000 - 50854 requests:
        - Avg: 27ms Fastest: 11ms Slowest: 276ms 50%: 26ms 90%: 35ms
 * http://minio-site1-db2:9000 - 51509 requests:
        - Avg: 27ms Fastest: 10ms Slowest: 270ms 50%: 26ms 90%: 35ms
 * http://minio-site1-db3:9000 - 50284 requests:
        - Avg: 27ms Fastest: 12ms Slowest: 265ms 50%: 26ms 90%: 36ms

----------------------------------------
Operation: GET - total: 915893, 60.0%, Size: 250000 bytes. Concurrency: 24, Ran 14m59s, starting 2022-12-13 19:48:23.675 +0530 +0530

Throughput by host:
 * http://minio-site1-db1:9000: Avg: 81.17 MiB/s, 340.44 obj/s.
 * http://minio-site1-db2:9000: Avg: 81.14 MiB/s, 340.35 obj/s.
 * http://minio-site1-db3:9000: Avg: 80.34 MiB/s, 336.99 obj/s.
```