### PR TITLE
support min/max obj.size to support better ranges (take 2)

### DIFF
--- a/pkg/bench/get.go
+++ b/pkg/bench/get.go
@@ -208,7 +208,7 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 				}
 				if g.RandomRanges && op.Size > 2 {
 					// Randomize length similar to --obj.randsize
-					size := generator.GetExpRandSize(rng, op.Size-2)
+					size := generator.GetExpRandSize(rng, 0, op.Size-2)
 					start := rng.Int63n(op.Size - size)
 					end := start + size
 					op.Size = end - start + 1

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -177,11 +177,11 @@ func randASCIIBytes(dst []byte, rng *rand.Rand) {
 // Minimum size: 127 bytes, max scale is 256 times smaller than max size.
 // Average size will be max_size * 0.179151.
 func GetExpRandSize(rng *rand.Rand, min, max int64) int64 {
-	if max < 10 {
-		if max == 0 {
+	if max-min < 10 {
+		if max-min <= 0 {
 			return 0
 		}
-		return 1 + rng.Int63n(max)
+		return 1 + min + rng.Int63n(max-min)
 	}
 	logSizeMax := math.Log2(float64(max - 1))
 	logSizeMin := math.Max(7, logSizeMax-8)
@@ -194,6 +194,6 @@ func GetExpRandSize(rng *rand.Rand, min, max int64) int64 {
 	if logSize > 1 {
 		return 1 + int64(math.Pow(2, logSize+logSizeMin))
 	}
-	// For lowest part, do linear
-	return 1 + int64(random*math.Pow(2, logSizeMin+1))
+	// For lowest part, do equal distribution
+	return 1 + min + int64(random*math.Pow(2, logSizeMin+1))
 }

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -176,7 +176,7 @@ func randASCIIBytes(dst []byte, rng *rand.Rand) {
 // GetExpRandSize will return an exponential random size from 1 to and including max.
 // Minimum size: 127 bytes, max scale is 256 times smaller than max size.
 // Average size will be max_size * 0.179151.
-func GetExpRandSize(rng *rand.Rand, max int64) int64 {
+func GetExpRandSize(rng *rand.Rand, min, max int64) int64 {
 	if max < 10 {
 		if max == 0 {
 			return 0
@@ -185,6 +185,9 @@ func GetExpRandSize(rng *rand.Rand, max int64) int64 {
 	}
 	logSizeMax := math.Log2(float64(max - 1))
 	logSizeMin := math.Max(7, logSizeMax-8)
+	if min > 0 {
+		logSizeMin = math.Log2(float64(min - 1))
+	}
 	lsDelta := logSizeMax - logSizeMin
 	random := rng.Float64()
 	logSize := random * lsDelta

--- a/pkg/generator/options.go
+++ b/pkg/generator/options.go
@@ -27,7 +27,6 @@ import (
 type Options struct {
 	src          func(o Options) (Source, error)
 	minSize      int64
-	maxSize      int64
 	totalSize    int64
 	randSize     bool
 	customPrefix string
@@ -46,10 +45,7 @@ func (o Options) getSize(rng *rand.Rand) int64 {
 	if !o.randSize {
 		return o.totalSize
 	}
-	if o.minSize > 0 {
-		return GetExpRandSize(rng, o.minSize, o.maxSize)
-	}
-	return GetExpRandSize(rng, 0, o.totalSize)
+	return GetExpRandSize(rng, o.minSize, o.totalSize)
 }
 
 func defaultOptions() Options {
@@ -80,6 +76,7 @@ func WithMinMaxSize(min, max int64) Option {
 		}
 
 		o.totalSize = max
+		o.minSize = min
 		return nil
 	}
 }

--- a/pkg/generator/options.go
+++ b/pkg/generator/options.go
@@ -26,6 +26,8 @@ import (
 // Use WithXXX functions to set them.
 type Options struct {
 	src          func(o Options) (Source, error)
+	minSize      int64
+	maxSize      int64
 	totalSize    int64
 	randSize     bool
 	customPrefix string
@@ -44,7 +46,10 @@ func (o Options) getSize(rng *rand.Rand) int64 {
 	if !o.randSize {
 		return o.totalSize
 	}
-	return GetExpRandSize(rng, o.totalSize)
+	if o.minSize > 0 {
+		return GetExpRandSize(rng, o.minSize, o.maxSize)
+	}
+	return GetExpRandSize(rng, 0, o.totalSize)
 }
 
 func defaultOptions() Options {
@@ -56,6 +61,27 @@ func defaultOptions() Options {
 		randomPrefix: 0,
 	}
 	return o
+}
+
+// WithMinMaxSize sets the min and max size of the generated data.
+func WithMinMaxSize(min, max int64) Option {
+	return func(o *Options) error {
+		if min <= 0 {
+			return errors.New("WithSize: minSize must be >= 0")
+		}
+		if max < 0 {
+			return errors.New("WithSize: maxSize must be > 0")
+		}
+		if min > max {
+			return errors.New("WithSize: minSize must be < maxSize")
+		}
+		if o.randSize && max < 256 {
+			return errors.New("WithSize: random sized objects should be at least 256 bytes")
+		}
+
+		o.totalSize = max
+		return nil
+	}
 }
 
 // WithSize sets the size of the generated data.


### PR DESCRIPTION
Actually use minimum value

Replaces https://github.com/minio/warp/pull/244 that never was activated (minSize never set).

Statistics confirmed with testing.