### PR TITLE
[get] bench object from listing the bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,19 +267,24 @@ Operation: DELETE
 A similar benchmark is called `versioned` which operates on versioned objects.
 
 ## GET
+Benchmarking get operations will attempt to download as many objects it can within `--duration`.
 
-Benchmarking get operations will upload `--objects` objects of size `--obj.size` 
-and attempt to download as many it can within `--duration`.
+By default, `--objects` objects of size `--obj.size` are uploaded before doing the actual bench.
+Objects will be uploaded with `--concurrent` different prefixes, except if `--noprefix` is specified.
+
+Using `--list-existing` will list at most `--objects` from the bucket and download them instead
+of uploading random objects (set it to 0 to use all object from the listing).
+Listing is restricted to `--prefix` if it is set and recursive listing can be disabled by setting `--list-flat`
 
 If versioned listing should be tested, it is possible by setting `--versions=n` (default 1),
 which will add multiple versions of each object and request individual versions.
 
-Objects will be uploaded with `--concurrent` different prefixes, 
-except if `--noprefix` is specified. Downloads are chosen randomly between all uploaded data.
-
-When downloading, the benchmark will attempt to run `--concurrent` concurrent downloads.
+When downloading, objects are chosen randomly between all uploaded data and the benchmark
+will attempt to run `--concurrent` concurrent downloads.
 
 The analysis will include the upload stats as `PUT` operations and the `GET` operations.
+
+
 
 ```
 Operation: GET

--- a/cli/get.go
+++ b/cli/get.go
@@ -25,6 +25,14 @@ import (
 )
 
 var getFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:  "list-existing",
+		Usage: "Instead of preparing the bench by PUTing some objects, only use objects already in the bucket",
+	},
+	cli.BoolFlag{
+		Name:  "list-flat",
+		Usage: "When using --list-existing, do not use recursive listing",
+	},
 	cli.IntFlag{
 		Name:  "objects",
 		Value: 2500,
@@ -82,6 +90,9 @@ func mainGet(ctx *cli.Context) error {
 		RandomRanges:  ctx.Bool("range"),
 		CreateObjects: ctx.Int("objects"),
 		GetOpts:       minio.GetObjectOptions{ServerSideEncryption: sse},
+		ListExisting:  ctx.Bool("list-existing"),
+		ListFlat:      ctx.Bool("list-flat"),
+		ListPrefix:    ctx.String("prefix"),
 	}
 	return runBench(ctx, &b)
 }

--- a/pkg/bench/get.go
+++ b/pkg/bench/get.go
@@ -38,6 +38,9 @@ type Get struct {
 	Collector     *Collector
 	objects       generator.Objects
 	Versions      int
+	ListExisting  bool
+	ListFlat      bool
+	ListPrefix    string
 
 	// Default Get options.
 	GetOpts minio.GetObjectOptions
@@ -47,6 +50,74 @@ type Get struct {
 // Prepare will create an empty bucket or delete any content already there
 // and upload a number of objects.
 func (g *Get) Prepare(ctx context.Context) error {
+	// prepare the bench by listing object from the bucket
+	if g.ListExisting {
+		cl, done := g.Client()
+
+		// ensure the bucket exist
+		found, err := cl.BucketExists(ctx, g.Bucket)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return (fmt.Errorf("bucket %s does not exist and --list-existing has been set", g.Bucket))
+		}
+
+		// list all objects
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		objectCh := cl.ListObjects(ctx, g.Bucket, minio.ListObjectsOptions{
+			WithVersions: g.Versions > 1,
+			Prefix:       g.ListPrefix,
+			Recursive:    !g.ListFlat,
+		})
+
+		versions := map[string]int{}
+
+		for object := range objectCh {
+			if object.Err != nil {
+				return object.Err
+			}
+			if object.Size == 0 {
+				continue
+			}
+			obj := generator.Object{
+				Name: object.Key,
+				Size: object.Size,
+			}
+
+			if g.Versions > 1 {
+				if object.VersionID == "" {
+					continue
+				}
+
+				if version, found := versions[object.Key]; found {
+					if version >= g.Versions {
+						continue
+					}
+					versions[object.Key]++
+				} else {
+					versions[object.Key] = 1
+				}
+				obj.VersionID = object.VersionID
+			}
+
+			g.objects = append(g.objects, obj)
+
+			// limit to ListingMaxObjects
+			if g.CreateObjects > 0 && len(g.objects) >= g.CreateObjects {
+				break
+			}
+		}
+		if len(g.objects) == 0 {
+			return (fmt.Errorf("no objects found for bucket %s", g.Bucket))
+		}
+		done()
+		g.Collector = NewCollector()
+		return nil
+	}
+
+	// prepare the bench by creating the bucket and pushing some objects
 	if err := g.createEmptyBucket(ctx); err != nil {
 		return err
 	}
@@ -251,5 +322,7 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 
 // Cleanup deletes everything uploaded to the bucket.
 func (g *Get) Cleanup(ctx context.Context) {
-	g.deleteAllInBucket(ctx, g.objects.Prefixes()...)
+	if !g.ListExisting {
+		g.deleteAllInBucket(ctx, g.objects.Prefixes()...)
+	}
 }


### PR DESCRIPTION
when doing a get bench, during the prepare phase, instead of putting objects in the bucket use the objects already in there. This can be used to bench a specific use case with an already filled in bucket. It can also be used to speed up get tests by always using the same objects and gain the prepare phase.

New options:
* `--get-from-listing-bucket`: to activate the listing bucket (current
  behaviour remains)
* `--listing-bucket-max-objects`: to limit the number of object to use
* `--listing-bucket-prefix`: to use a specific prefix during listing
* `--listing-bucket-no-recursive`: disable recursive listing