### PR TITLE
Add Snowball benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,59 @@ Throughput, split into 59 x 1s:
 
 This will only work on recent MinIO versions, from 2022 and going forward.
 
+## SNOWBALL
+
+The Snowball benchmark will test uploading a "snowball" TAR file with multiple files inside that are extracted as individual objects.
+
+Parameters:
+
+* `--obj.size=N` controls the size of each object inside the TAR file that is uploaded. Default is 512KiB.
+* `--objs.per=N` controls the number of objects per TAR file. Default is 50.
+* `--compress` will compress the TAR file before upload. Object data will be duplicated inside each TAR. This limits `--obj.size` to 10MiB.
+
+Since TAR operations are done in-memory the total size is limited to 1GiB.
+
+This is calculated as `--obj.size` * `--concurrent`. 
+If `--compress` is NOT specified this is also multiplied by `--objs.per`. 
+
+Examples:
+
+Benchmark using default parameters. 50 x 512KiB duplicated objects inside each TAR file. Compressed.
+```
+λ warp snowball --duration=30s --compress
+warp: Benchmark data written to "warp-snowball-2023-04-06[115116]-9S9Z.csv.zst"
+
+----------------------------------------
+Operation: PUT
+* Average: 223.90 MiB/s, 447.80 obj/s
+
+Throughput, split into 26 x 1s:
+ * Fastest: 261.0MiB/s, 522.08 obj/s
+ * 50% Median: 237.7MiB/s, 475.32 obj/s
+ * Slowest: 151.6MiB/s, 303.27 obj/s
+warp: Cleanup Done.
+```
+
+Test 1000 unique 1KB objects inside each snowball, with 2 concurrent uploads running:
+```
+λ warp snowball --duration=60s --obj.size=1K --objs.per=1000 --concurrent=2
+warp: Benchmark data written to "warp-snowball-2023-04-06[114915]-W3zw.csv.zst"
+
+----------------------------------------
+Operation: PUT
+* Average: 0.93 MiB/s, 975.72 obj/s
+
+Throughput, split into 56 x 1s:
+ * Fastest: 1051.9KiB/s, 1077.12 obj/s
+ * 50% Median: 1010.0KiB/s, 1034.26 obj/s
+ * Slowest: 568.2KiB/s, 581.84 obj/s
+warp: Cleanup Done.
+```
+
+The analysis throughput represents the object count and sizes as they are written when extracted.
+
+Request times shown with `--analyze.v` represents request time for each snowball.
+
 # Analysis
 
 When benchmarks have finished all request data will be saved to a file and an analysis will be shown.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -96,6 +96,7 @@ func init() {
 		retentionCmd,
 		multipartCmd,
 		zipCmd,
+		snowballCmd,
 	}
 	b := []cli.Command{
 		analyzeCmd,

--- a/cli/snowball.go
+++ b/cli/snowball.go
@@ -1,0 +1,133 @@
+/*
+ * Warp (C) 2019-2023 MinIO, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"github.com/minio/cli"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/pkg/console"
+	"github.com/minio/warp/pkg/bench"
+)
+
+var snowballFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "obj.size",
+		Value: "512KiB",
+		Usage: "Size of each generated object inside the snowball. Can be a number or 10KiB/MiB/GiB. All sizes are base 2 binary.",
+	},
+	cli.IntFlag{
+		Name:  "objs.per",
+		Value: 50,
+		Usage: "Number of objects per snowball upload.",
+	},
+	cli.BoolFlag{
+		Name:  "compress",
+		Usage: "Compress each snowball file. Available for MinIO servers only.",
+	},
+}
+
+// Put command.
+var snowballCmd = cli.Command{
+	Name:   "snowball",
+	Usage:  "benchmark put objects in snowball tar files",
+	Action: mainSnowball,
+	Before: setGlobalsFromContext,
+	Flags:  combineFlags(globalFlags, ioFlags, snowballFlags, genFlags, benchFlags, analyzeFlags),
+	CustomHelpTemplate: `NAME:
+  {{.HelpName}} - {{.Usage}}
+
+USAGE:
+  {{.HelpName}} [FLAGS]
+  -> see https://github.com/minio/warp#snowball
+
+FLAGS:
+  {{range .VisibleFlags}}{{.}}
+  {{end}}`,
+}
+
+// mainPut is the entry point for cp command.
+func mainSnowball(ctx *cli.Context) error {
+	checkSnowballSyntax(ctx)
+	src := newGenSource(ctx, "obj.size")
+	b := bench.Snowball{
+		Common: bench.Common{
+			Client:      newClient(ctx),
+			Concurrency: ctx.Int("concurrent"),
+			Source:      src,
+			Bucket:      ctx.String("bucket"),
+			Location:    "",
+			PutOpts:     snowballOpts(ctx),
+		},
+		Compress:  ctx.Bool("compress"),
+		Duplicate: ctx.Bool("compress"),
+		NumObjs:   ctx.Int("objs.per"),
+	}
+	if b.Compress {
+		sz, err := toSize(ctx.String("obj.size"))
+		if err != nil {
+			return err
+		}
+		b.WindowSize = int(sz) * 2
+		if b.WindowSize < 128<<10 {
+			b.WindowSize = 128 << 10
+		}
+		if b.WindowSize > 16<<20 {
+			b.WindowSize = 16 << 20
+		}
+	}
+	return runBench(ctx, &b)
+}
+
+// putOpts retrieves put options from the context.
+func snowballOpts(ctx *cli.Context) minio.PutObjectOptions {
+	return minio.PutObjectOptions{
+		ServerSideEncryption: newSSE(ctx),
+		DisableMultipart:     ctx.Bool("disable-multipart"),
+		SendContentMd5:       ctx.Bool("md5"),
+		StorageClass:         ctx.String("storage-class"),
+	}
+}
+
+func checkSnowballSyntax(ctx *cli.Context) {
+	if ctx.NArg() > 0 {
+		console.Fatal("Command takes no arguments")
+	}
+
+	// 1GB max total.
+	const maxSize = 1 << 30
+	sz, err := toSize(ctx.String("obj.size"))
+	if err != nil {
+		console.Fatalf("Unable to parse --obj.size: %v", err)
+	}
+	gotTotal := int64(sz) * int64(ctx.Int("concurrent"))
+	compress := ctx.Bool("compress")
+	if compress && sz > 10<<20 {
+		console.Fatal("--obj.size must be <= 10MiB when compression is enabled")
+	}
+	if !compress {
+		gotTotal *= int64(ctx.Int("objs.per"))
+	}
+	if gotTotal > maxSize {
+		console.Fatalf("total size (%d) exceeds 1GiB", gotTotal)
+	}
+	if gotTotal <= 0 {
+		console.Fatalf("Parameters results in no expected output")
+	}
+	checkAnalyze(ctx)
+	checkBenchmark(ctx)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.14.1
-	github.com/klauspost/compress v1.15.15
+	github.com/klauspost/compress v1.16.4
 	github.com/minio/cli v1.24.2
 	github.com/minio/madmin-go/v2 v2.0.14
 	github.com/minio/mc v0.0.0-20230221173238-1843bab50013
 	github.com/minio/md5-simd v1.1.2
-	github.com/minio/minio-go/v7 v7.0.49
+	github.com/minio/minio-go/v7 v7.0.50
 	github.com/minio/pkg v1.6.3
 	github.com/minio/websocket v1.6.0
 	github.com/posener/complete v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
-github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
+github.com/klauspost/compress v1.16.4 h1:91KN02FnsOYhuunwU4ssRe8lc2JosWmizWa91B5v1PU=
+github.com/klauspost/compress v1.16.4/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
@@ -79,8 +79,8 @@ github.com/minio/mc v0.0.0-20230221173238-1843bab50013 h1:+4Zrme5jLaQ7o8O3CMMZbO
 github.com/minio/mc v0.0.0-20230221173238-1843bab50013/go.mod h1:Yuxzld65ajOb1I89IfxInz0wqSIgHv+8NTiuoX+O+o8=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
-github.com/minio/minio-go/v7 v7.0.49 h1:dE5DfOtnXMXCjr/HWI6zN9vCrY6Sv666qhhiwUMvGV4=
-github.com/minio/minio-go/v7 v7.0.49/go.mod h1:UI34MvQEiob3Cf/gGExGMmzugkM/tNgbFypNDy5LMVc=
+github.com/minio/minio-go/v7 v7.0.50 h1:4IL4V8m/kI90ZL6GupCARZVrBv8/XrcKcJhaJ3iz68k=
+github.com/minio/minio-go/v7 v7.0.50/go.mod h1:IbbodHyjUAguneyucUaahv+VMNs/EOTV9du7A7/Z3HU=
 github.com/minio/mux v1.8.2 h1:r9oVDFM09y+u8CF4HPLanguAG41niXgYwZAFkVHce9M=
 github.com/minio/pkg v1.6.3 h1:8XTM8pmlR5WZyy0rYxKj7nieRgwns07Vq4FejUsg+SM=
 github.com/minio/pkg v1.6.3/go.mod h1:ijZyWsfvtS0AcY6WT86AJ9VcK8gSsu++U28qlNCy9A0=

--- a/pkg/bench/multipart.go
+++ b/pkg/bench/multipart.go
@@ -119,8 +119,11 @@ func (g *Multipart) Prepare(ctx context.Context) error {
 					Endpoint: client.EndpointURL().String(),
 				}
 				opts.ContentType = obj.ContentType
+				mpopts := minio.PutObjectPartOptions{
+					SSE: g.Common.PutOpts.ServerSideEncryption,
+				}
 				op.Start = time.Now()
-				res, err := core.PutObjectPart(ctx, g.Bucket, obj.Name, g.UploadID, partN, obj.Reader, obj.Size, "", "", g.Common.PutOpts.ServerSideEncryption)
+				res, err := core.PutObjectPart(ctx, g.Bucket, obj.Name, g.UploadID, partN, obj.Reader, obj.Size, mpopts)
 				op.End = time.Now()
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)

--- a/pkg/bench/snowball.go
+++ b/pkg/bench/snowball.go
@@ -1,0 +1,201 @@
+/*
+ * Warp (C) 2019-2023 MinIO, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bench
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// Snowball benchmarks snowball upload speed.
+type Snowball struct {
+	NumObjs    int  // Number objects in each snowball.
+	Duplicate  bool // Duplicate object content.
+	Compress   bool // Zstandard compress snowball.
+	Collector  *Collector
+	WindowSize int
+	prefixes   map[string]struct{}
+
+	enc []*zstd.Encoder
+	Common
+}
+
+// Prepare will create an empty bucket or delete any content already there
+// and upload a number of objects.
+func (s *Snowball) Prepare(ctx context.Context) error {
+	if s.Compress {
+		s.enc = make([]*zstd.Encoder, s.Concurrency)
+		for i := range s.enc {
+			var err error
+			s.enc[i], err = zstd.NewWriter(nil, zstd.WithEncoderConcurrency(1), zstd.WithEncoderLevel(zstd.SpeedFastest), zstd.WithWindowSize(s.WindowSize), zstd.WithNoEntropyCompression(true), zstd.WithAllLitEntropyCompression(false))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	s.prefixes = make(map[string]struct{}, s.Concurrency)
+	if err := s.createEmptyBucket(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Start will execute the main benchmark.
+// Operations should begin executing when the start channel is closed.
+func (s *Snowball) Start(ctx context.Context, wait chan struct{}) (Operations, error) {
+	var wg sync.WaitGroup
+	wg.Add(s.Concurrency)
+	c := NewCollector()
+	if s.AutoTermDur > 0 {
+		ctx = c.AutoTerm(ctx, http.MethodPut, s.AutoTermScale, autoTermCheck, autoTermSamples, s.AutoTermDur)
+	}
+	s.prefixes = make(map[string]struct{}, s.Concurrency)
+
+	// Non-terminating context.
+	nonTerm := context.Background()
+
+	for i := 0; i < s.Concurrency; i++ {
+		src := s.Source()
+		s.prefixes[src.Prefix()] = struct{}{}
+		go func(i int) {
+			var buf bytes.Buffer
+			rcv := c.Receiver()
+			defer wg.Done()
+			opts := s.PutOpts
+			opts.UserMetadata = map[string]string{"X-Amz-Meta-Snowball-Auto-Extract": "true"}
+			done := ctx.Done()
+
+			<-wait
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				buf.Reset()
+				w := io.Writer(&buf)
+				if s.Compress {
+					s.enc[i].Reset(&buf)
+					w = s.enc[i]
+				}
+				obj := src.Object()
+				op := Operation{
+					OpType:   http.MethodPut,
+					Thread:   uint16(i),
+					File:     path.Join(obj.Prefix, "snowball.tar"),
+					ObjPerOp: s.NumObjs,
+				}
+				{
+					tw := tar.NewWriter(w)
+					content, err := io.ReadAll(obj.Reader)
+					if err != nil {
+						s.Error("obj data error: ", err)
+						return
+					}
+
+					for i := 0; i < s.NumObjs; i++ {
+						err := tw.WriteHeader(&tar.Header{
+							Typeflag: tar.TypeReg,
+							Name:     fmt.Sprintf("%s/%d.obj", obj.Name, i),
+							Size:     obj.Size,
+							Mode:     int64(os.ModePerm),
+							ModTime:  time.Now(),
+						})
+						if err != nil {
+							s.Error("tar header error: ", err)
+							return
+						}
+						_, err = tw.Write(content)
+						if err != nil {
+							s.Error("tar write error: ", err)
+							return
+						}
+						op.Size += int64(len(content))
+						if !s.Duplicate {
+							obj = src.Object()
+							content, err = io.ReadAll(obj.Reader)
+							if err != nil {
+								s.Error("obj data error: ", err)
+								return
+							}
+						}
+					}
+					tw.Close()
+					if s.Compress {
+						err := s.enc[i].Close()
+						if err != nil {
+							s.Error("zstd close error: ", err)
+							return
+						}
+					}
+				}
+				opts.ContentType = obj.ContentType
+				opts.DisableMultipart = true
+
+				client, cldone := s.Client()
+				op.Endpoint = client.EndpointURL().String()
+				op.Start = time.Now()
+				tarLength := int64(buf.Len())
+				// fmt.Println(op.Size, "->", tarLength, math.Round(100*float64(tarLength)/float64(op.Size)), "%")
+				res, err := client.PutObject(nonTerm, s.Bucket, obj.Name+".tar", &buf, tarLength, opts)
+				op.End = time.Now()
+				if err != nil {
+					s.Error("upload error: ", err)
+					op.Err = err.Error()
+				}
+				obj.VersionID = res.VersionID
+
+				if res.Size != tarLength && op.Err == "" {
+					err := fmt.Sprint("short upload. want:", tarLength, ", got:", res.Size)
+					if op.Err == "" {
+						op.Err = err
+					}
+					s.Error(err)
+				}
+				cldone()
+				rcv <- op
+			}
+		}(i)
+	}
+	wg.Wait()
+	return c.Close(), nil
+}
+
+// Cleanup deletes everything uploaded to the bucket.
+func (s *Snowball) Cleanup(ctx context.Context) {
+	if s.Compress {
+		for i := range s.enc {
+			s.enc[i] = nil
+		}
+	}
+	var pf []string
+	for p := range s.prefixes {
+		pf = append(pf, p)
+	}
+	s.deleteAllInBucket(ctx, pf...)
+}


### PR DESCRIPTION
The Snowball benchmark will test uploading a "snowball" TAR file with multiple files inside that are extracted as individual objects.

Parameters:

* `--obj.size=N` controls the size of each object inside the TAR file that is uploaded. Default is 512KiB.
* `--objs.per=N` controls the number of objects per TAR file. Default is 50.
* `--compress` will compress the TAR file before upload. Object data will be duplicated inside each TAR. This limits `--obj.size` to 10MiB.

Since TAR operations are done in-memory the total size is limited to 1GiB.

This is calculated as `--obj.size` * `--concurrent`. If `--compress` is NOT specified this is also multiplied by `--objs.per`.

Examples:

Benchmark using default parameters. 50 x 512KiB duplicated objects inside each TAR file. Compressed.
```
λ warp snowball --duration=30s --compress
warp: Benchmark data written to "warp-snowball-2023-04-06[115116]-9S9Z.csv.zst"

----------------------------------------
Operation: PUT
* Average: 223.90 MiB/s, 447.80 obj/s

Throughput, split into 26 x 1s:
 * Fastest: 261.0MiB/s, 522.08 obj/s
 * 50% Median: 237.7MiB/s, 475.32 obj/s
 * Slowest: 151.6MiB/s, 303.27 obj/s
warp: Cleanup Done.
```

Test 1000 unique 1KB objects inside each snowball, with 2 concurrent uploads running:
```
λ warp snowball --duration=60s --obj.size=1K --objs.per=1000 --concurrent=2
warp: Benchmark data written to "warp-snowball-2023-04-06[114915]-W3zw.csv.zst"

----------------------------------------
Operation: PUT
* Average: 0.93 MiB/s, 975.72 obj/s

Throughput, split into 56 x 1s:
 * Fastest: 1051.9KiB/s, 1077.12 obj/s
 * 50% Median: 1010.0KiB/s, 1034.26 obj/s
 * Slowest: 568.2KiB/s, 581.84 obj/s
warp: Cleanup Done.
```

The analysis throughput represents the object count and sizes as they are written when extracted.

Request times shown with `--analyze.v` represents request time for each snowball.