### PR TITLE
Optimize analysis on multiple hosts

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -423,8 +424,10 @@ func writeSegs(ctx *cli.Context, wrSegs io.Writer, ops bench.Operations, allThre
 
 	// Write segments per endpoint
 	eps := ops.SortSplitByEndpoint()
+	epsSorted := stringKeysSorted(eps)
 	if details && len(eps) > 1 {
-		for _, ops := range eps {
+		for _, ep := range epsSorted {
+			ops := eps[ep]
 			segs := ops.Segment(bench.SegmentOptions{
 				From:           start,
 				PerSegDuration: aDur,
@@ -636,4 +639,14 @@ func checkAnalyze(ctx *cli.Context) {
 		err := errors.New("-analyze.dur cannot be 0")
 		fatal(probe.NewError(err), "Invalid -analyze.dur value")
 	}
+}
+
+// stringKeysSorted returns the keys as a sorted string slice.
+func stringKeysSorted[K string, V any](m map[K]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, string(k))
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -405,6 +405,7 @@ func writeSegs(ctx *cli.Context, wrSegs io.Writer, ops bench.Operations, allThre
 	}
 	totalDur := ops.Duration()
 	aDur := analysisDur(ctx, totalDur)
+	ops.SortByStartTime()
 	segs := ops.Segment(bench.SegmentOptions{
 		From:           time.Time{},
 		PerSegDuration: aDur,
@@ -421,10 +422,9 @@ func writeSegs(ctx *cli.Context, wrSegs io.Writer, ops bench.Operations, allThre
 	wantSegs := len(segs)
 
 	// Write segments per endpoint
-	eps := ops.Endpoints()
+	eps := ops.SortSplitByEndpoint()
 	if details && len(eps) > 1 {
-		for _, ep := range eps {
-			ops := ops.FilterByEndpoint(ep)
+		for _, ops := range eps {
 			segs := ops.Segment(bench.SegmentOptions{
 				From:           start,
 				PerSegDuration: aDur,

--- a/pkg/bench/analyze.go
+++ b/pkg/bench/analyze.go
@@ -171,6 +171,7 @@ func (o Operations) Segment(so SegmentOptions) Segments {
 	if e := o.Endpoints(); len(e) == 1 {
 		host = e[0]
 	}
+	ops := o
 	for segStart.Before(end.Add(-so.PerSegDuration)) {
 		s := Segment{
 			OpType:     o.FirstOpType(),
@@ -191,17 +192,19 @@ func (o Operations) Segment(so SegmentOptions) Segments {
 		}
 		// Search for the first entry
 		first := 0
-		for i, op := range o {
+		for i := range ops {
+			op := &ops[i]
 			if op.End.After(s.Start) {
 				break
 			}
 			first = i
 		}
-		for _, op := range o[first:] {
+		for _, op := range ops[first:] {
 			if op.Aggregate(&s) {
 				break
 			}
 		}
+		ops = ops[first:]
 		if s.OpsEnded > 0 {
 			s.ReqAvg /= float64(s.OpsEnded)
 		}

--- a/pkg/bench/compare.go
+++ b/pkg/bench/compare.go
@@ -256,6 +256,7 @@ func Compare(before, after Operations, analysis time.Duration, allThreads bool) 
 	}
 	res.Op = before.FirstOpType()
 	segment := func(ops Operations) (Segments, error) {
+		ops.SortByStartTime()
 		segs := ops.Segment(SegmentOptions{
 			From:           time.Time{},
 			PerSegDuration: analysis,


### PR DESCRIPTION
Before: Duration: 189.16s, Total samples = 1489.30s (787.30%)
After: Duration: 97.52s, Total samples = 167.14s (171.39%)

50% wall time reduction, much bigger core reduction.

Results match.