### PR TITLE
check bucket locking status before clean up

### DIFF
--- a/pkg/bench/benchmark.go
+++ b/pkg/bench/benchmark.go
@@ -215,7 +215,13 @@ func (c *Common) deleteAllInBucket(ctx context.Context, prefixes ...string) {
 		}
 	}()
 
-	errCh := cl.RemoveObjects(ctx, c.Bucket, objectsCh, minio.RemoveObjectsOptions{GovernanceBypass: true})
+	delOpts := minio.RemoveObjectsOptions{}
+	_, _, _, errLock := cl.GetBucketObjectLockConfig(ctx, c.Bucket)
+	if errLock == nil {
+		delOpts.GovernanceBypass = true
+	}
+
+	errCh := cl.RemoveObjects(ctx, c.Bucket, objectsCh, delOpts)
 	for err := range errCh {
 		if err.Err != nil {
 			c.Error(err.Err)


### PR DESCRIPTION
This would fix #284, this checks the bucket `ObjectLockConfiguration`,  and if one is present, sets the proper `RemoveObjectsOptions` field `GovernanceBypass`, as it can't normally be passed if the bucket is not "locked". 

This is my first time with Go, so sorry in advance if the code is not following best practices or is not idiomatic. 