### PR TITLE
analysis: add space before printing filename

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -244,7 +244,7 @@ func printAnalysis(ctx *cli.Context, o bench.Operations) {
 		} else {
 			f, err := os.Create(fn)
 			fatalIf(probe.NewError(err), "Unable to create create analysis output")
-			defer console.Println("Aggregated data saved to", fn)
+			defer console.Println("Aggregated data saved to ", fn)
 			defer f.Close()
 			wrSegs = f
 		}

--- a/cli/cmp.go
+++ b/cli/cmp.go
@@ -84,7 +84,7 @@ func printCompare(ctx *cli.Context, before, after bench.Operations) {
 		} else {
 			f, err := os.Create(fn)
 			fatalIf(probe.NewError(err), "Unable to create create analysis output")
-			defer console.Println("Aggregated data saved to", fn)
+			defer console.Println("Aggregated data saved to ", fn)
 			defer f.Close()
 			wrSegs = f
 		}


### PR DESCRIPTION
Currently, the output looks like:

```
Aggregated data saved toFILENAME.txt
```

There should be a space after 'to', so that's what this PR adds.