### PR TITLE
Update goreleaser to support more architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,6 +72,15 @@ nfpms:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
 dockers:
+  -
+    # GOOS of the built binary that should be used.
+    goos: linux
+    # GOARCH of the built binary that should be used.
+    goarch: amd64
+    dockerfile: Dockerfile.release
+    image_templates:
+      - "minio/warp:{{ .Tag }}"
+      - "minio/warp:latest"
   - image_templates:
       - "quay.io/minio/warp:{{ .Tag }}-amd64"
     use: buildx

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,7 +80,6 @@ dockers:
     dockerfile: Dockerfile.release
   - image_templates:
       - "quay.io/minio/warp:{{ .Tag }}-amd64"
-      - "minio/warp:{{ .Tag }}-amd64"
     use: buildx
     goarch: amd64
     ids:
@@ -90,7 +89,6 @@ dockers:
       - "--platform=linux/amd64"
   - image_templates:
       - "quay.io/minio/warp:{{ .Tag }}-arm64"
-      - "minio/warp:{{ .Tag }}-arm64"
     use: buildx
     goarch: arm64
     ids:
@@ -100,7 +98,6 @@ dockers:
       - "--platform=linux/arm64"
   - image_templates:
       - "quay.io/minio/warp:latest-amd64"
-      - "minio/warp:latest-amd64"
     use: buildx
     goarch: amd64
     ids:
@@ -110,7 +107,6 @@ dockers:
       - "--platform=linux/amd64"
   - image_templates:
       - "quay.io/minio/warp:latest-arm64"
-      - "minio/warp:latest-arm64"
     use: buildx
     goarch: arm64
     ids:
@@ -119,7 +115,42 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64"
 
-
+  - image_templates:
+      - "minio/warp:{{ .Tag }}-amd64"
+    use: buildx
+    goarch: amd64
+    ids:
+      - warp
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "minio/warp:{{ .Tag }}-arm64"
+    use: buildx
+    goarch: arm64
+    ids:
+      - warp
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/arm64"
+  - image_templates:
+      - "minio/warp:latest-amd64"
+    use: buildx
+    goarch: amd64
+    ids:
+      - warp
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "minio/warp:latest-arm64"
+    use: buildx
+    goarch: arm64
+    ids:
+      - warp
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/arm64"
 docker_manifests:
   - name_template: minio/warp:{{ .Tag }}
     image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,12 +72,30 @@ nfpms:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
 dockers:
-  -
-    # GOOS of the built binary that should be used.
-    goos: linux
-    # GOARCH of the built binary that should be used.
+  - image_templates:
+      - "quay.io/minio/warp:{{ .Tag }}-amd64"
+    use: buildx
     goarch: amd64
+    ids:
+      - warp
     dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "quay.io/minio/warp:{{ .Tag }}-arm64"
+    use: buildx
+    goarch: arm64
+    ids:
+      - warp
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/arm64"
+docker_manifests:
+  - name_template: quay.io/minio/warp:{{ .Tag }}
     image_templates:
-      - "minio/warp:{{ .Tag }}"
-      - "minio/warp:latest"
+      - quay.io/minio/warp:{{ .Tag }}-amd64
+      - quay.io/minio/warp:{{ .Tag }}-arm64
+  - name_template: quay.io/minio/warp:latest
+    image_templates:
+      - quay.io/minio/warp:{{ .Tag }}-amd64
+      - quay.io/minio/warp:{{ .Tag }}-arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,11 +78,9 @@ dockers:
     # GOARCH of the built binary that should be used.
     goarch: amd64
     dockerfile: Dockerfile.release
-    image_templates:
-      - "minio/warp:{{ .Tag }}"
-      - "minio/warp:latest"
   - image_templates:
       - "quay.io/minio/warp:{{ .Tag }}-amd64"
+      - "minio/warp:{{ .Tag }}-amd64"
     use: buildx
     goarch: amd64
     ids:
@@ -92,6 +90,7 @@ dockers:
       - "--platform=linux/amd64"
   - image_templates:
       - "quay.io/minio/warp:{{ .Tag }}-arm64"
+      - "minio/warp:{{ .Tag }}-arm64"
     use: buildx
     goarch: arm64
     ids:
@@ -99,12 +98,42 @@ dockers:
     dockerfile: Dockerfile.release
     build_flag_templates:
       - "--platform=linux/arm64"
+  - image_templates:
+      - "quay.io/minio/warp:latest-amd64"
+      - "minio/warp:latest-amd64"
+    use: buildx
+    goarch: amd64
+    ids:
+      - warp
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "quay.io/minio/warp:latest-arm64"
+      - "minio/warp:latest-arm64"
+    use: buildx
+    goarch: arm64
+    ids:
+      - warp
+    dockerfile: Dockerfile.release
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+
 docker_manifests:
+  - name_template: minio/warp:{{ .Tag }}
+    image_templates:
+      - minio/warp:{{ .Tag }}-amd64
+      - minio/warp:{{ .Tag }}-arm64
+  - name_template: minio/warp:latest
+    image_templates:
+      - minio/warp:latest-amd64
+      - minio/warp:latest-arm64
   - name_template: quay.io/minio/warp:{{ .Tag }}
     image_templates:
       - quay.io/minio/warp:{{ .Tag }}-amd64
       - quay.io/minio/warp:{{ .Tag }}-arm64
   - name_template: quay.io/minio/warp:latest
     image_templates:
-      - quay.io/minio/warp:{{ .Tag }}-amd64
-      - quay.io/minio/warp:{{ .Tag }}-arm64
+      - quay.io/minio/warp:latest-amd64
+      - quay.io/minio/warp:latest-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.22
 
 ADD go.mod /go/src/github.com/minio/warp/go.mod
 ADD go.sum /go/src/github.com/minio/warp/go.sum


### PR DESCRIPTION
This PR supports the addition of more architectures to the Warp docker repository.

It keeps the original docker.com releases of `amd64`, while adding new `amd64` and `arm64` images at `quay.io`.