### PR TITLE
fix: goreleaser action is running twice on PR's to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: goreleaser
 
 on:
   pull_request:
-  push:
+    types: [ opened, reopened, synchronize ]
+    branches:
+      - 'master'
 
 jobs:
   goreleaser:


### PR DESCRIPTION
goreleaser github action is running twice on PR's to master branch, for example:
https://github.com/minio/warp/pull/334/checks

![image](https://github.com/user-attachments/assets/4da75e6c-9d32-441d-af90-48007dda36ba)
