### PR TITLE
Add a format for object-size providing a wieighted random based on configured buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ By default warp uploads random data.
 
 ### Object Size
 
+#### Fixed File Size
+
 Most benchmarks use the `--obj.size` parameter to decide the size of objects to upload.
 
 Different benchmark types will have different default values.
@@ -240,6 +242,20 @@ Throughput, split into 29 x 1s:
 The average object size will be close to `--obj.size` multiplied by 0.179151. 
 
 To get a value for `--obj.size` multiply the desired average object size by 5.582 to get a maximum value. 
+
+#### Bucketed File Size
+
+The `--obj.size` parameter accepts a string value whose format can describe size buckets.
+The usage of that format activates the options of bucketed file sizes and preempts a possible activation
+of random files sizes via `--obj.randsize`.
+
+The format of the string is a coma-separated of colon-separated pairs, describing buckets and their respective weights.
+Within each bucket, the size distribution is uniform.
+
+E.g.: the value `4096:10740,8192:1685,16384:1623` will trigger objects whose size will be chosen
+between 0 and 4096 with a weight of 10740, between 4096 and 8192 with a weight of 1685,
+or between 8192 and 16384 with a weight of 1623.
+
 
 ## Automatic Termination
 Adding `--autoterm` parameter will enable automatic termination when results are considered stable. 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.17.0
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0
+	github.com/jfsmig/prng v0.0.2
 	github.com/klauspost/compress v1.17.9
 	github.com/minio/cli v1.24.2
 	github.com/minio/madmin-go/v3 v3.0.51

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.13.0 h1:ioBbLmR5NMbAjP4UVA5r9b5xG
 github.com/influxdata/influxdb-client-go/v2 v2.13.0/go.mod h1:k+spCbt9hcvqvUiz0sr5D8LolXHqAAOfPw9v/RIRHl4=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf h1:7JTmneyiNEwVBOHSjoMxiWAqB992atOeepeFYegn5RU=
 github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
+github.com/jfsmig/prng v0.0.2 h1:aZun+YgmBnUyhqvI+EDjwmOYc1kCPsihdEr9V/1YlGA=
+github.com/jfsmig/prng v0.0.2/go.mod h1:bz1fX1aizp8/Lu1thLzfirh5uExjC1lVwB8SSt6ExpE=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=


### PR DESCRIPTION
Allows a coma-separated set of colon-separated pairs, describing buckets and their respective weights. This format triggers an option that performs a weighted random number generation when a new object is created.

E.g.: `4096:10740,8192:1685,16384:1623` will trigger objects whose size will be chosen between 0 and 4096 with a weight of 10740, between 4096 and 8192 with a weight of 1685, or between 8192 and 16384 with a weight of 1623.