### PR TITLE
Add lookup type override

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -157,12 +157,17 @@ func getClient(ctx *cli.Context, host string) (*minio.Client, error) {
 	default:
 		fatal(probe.NewError(errors.New("unknown signature method. S3V2 and S3V4 is available")), strings.ToUpper(ctx.String("signature")))
 	}
-
+	lookup := minio.BucketLookupAuto
+	if ctx.String("lookup") == "host" {
+		lookup = minio.BucketLookupDNS
+	} else if ctx.String("lookup") == "path" {
+		lookup = minio.BucketLookupPath
+	}
 	cl, err := minio.New(host, &minio.Options{
 		Creds:        creds,
 		Secure:       ctx.Bool("tls"),
 		Region:       ctx.String("region"),
-		BucketLookup: minio.BucketLookupAuto,
+		BucketLookup: lookup,
 		CustomMD5:    md5simd.NewServer().NewHash,
 		Transport:    clientTransport(ctx),
 	})

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -269,6 +269,10 @@ var ioFlags = []cli.Flag{
 		Value: 0,
 		Usage: "Rate limit each instance to this number of requests per second (0 to disable)",
 	},
+	cli.StringFlag{
+		Name:  "lookup",
+		Usage: "Force requests to be 'host' for host-style or 'path' for path-style lookup. Default will attempt autodetect based on remote host name.",
+	},
 }
 
 func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {


### PR DESCRIPTION
Instead of always auto-detecting, allow setting explicitly with `--lookup=host` or `--lookup=path`.

Fixes #346