### PR TITLE
add --metadata and --tag during put operations

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -273,6 +273,16 @@ var ioFlags = []cli.Flag{
 		Name:  "lookup",
 		Usage: "Force requests to be 'host' for host-style or 'path' for path-style lookup. Default will attempt autodetect based on remote host name.",
 	},
+	cli.StringSliceFlag{
+		Name:   "metadata",
+		Usage:  "Add user metada to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --metadata foo=bar --metadata randomValue=rand:1024.",
+		Hidden: true,
+	},
+	cli.StringSliceFlag{
+		Name:   "tag",
+		Usage:  "Add user tag to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --tag foo=bar --tag randomValue=rand:1024.",
+		Hidden: true,
+	},
 }
 
 func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {


### PR DESCRIPTION
- the new `--metadata key=value` flag allow to set user metadata during write operations.
- the new `--tag key=value` flag allow to set user tag during write operations.

this can be used to test some S3 services with more complex scenarios