### PR TITLE
fix: rename `metadata` flag to `add-metadata` for put operations

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -274,8 +274,8 @@ var ioFlags = []cli.Flag{
 		Usage: "Force requests to be 'host' for host-style or 'path' for path-style lookup. Default will attempt autodetect based on remote host name.",
 	},
 	cli.StringSliceFlag{
-		Name:   "metadata",
-		Usage:  "Add user metada to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --metadata foo=bar --metadata randomValue=rand:1024.",
+		Name:   "add-metadata",
+		Usage:  "Add user metadata to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --add-metadata foo=bar --add-metadata randomValue=rand:1024.",
 		Hidden: true,
 	},
 	cli.StringSliceFlag{

--- a/cli/list.go
+++ b/cli/list.go
@@ -40,7 +40,7 @@ var listFlags = []cli.Flag{
 		Usage: "Size of each generated object. Can be a number or 10KB/MB/GB. All sizes are base 2 binary.",
 	},
 	cli.BoolFlag{
-		Name:  "metadata",
+		Name:  "extended-metadata",
 		Usage: "Enable extended MinIO ListObjects with metadata, by default this benchmarking uses ListObjectsV2 API.",
 	},
 }
@@ -72,7 +72,7 @@ func mainList(ctx *cli.Context) error {
 	b := bench.List{
 		Common:        getCommon(ctx, newGenSource(ctx, "obj.size")),
 		Versions:      ctx.Int("versions"),
-		Metadata:      ctx.Bool("metadata"),
+		Metadata:      ctx.Bool("extended-metadata"),
 		CreateObjects: ctx.Int("objects"),
 		NoPrefix:      ctx.Bool("noprefix"),
 	}

--- a/cli/list.go
+++ b/cli/list.go
@@ -40,7 +40,7 @@ var listFlags = []cli.Flag{
 		Usage: "Size of each generated object. Can be a number or 10KB/MB/GB. All sizes are base 2 binary.",
 	},
 	cli.BoolFlag{
-		Name:  "extended-metadata",
+		Name:  "metadata",
 		Usage: "Enable extended MinIO ListObjects with metadata, by default this benchmarking uses ListObjectsV2 API.",
 	},
 }
@@ -72,7 +72,7 @@ func mainList(ctx *cli.Context) error {
 	b := bench.List{
 		Common:        getCommon(ctx, newGenSource(ctx, "obj.size")),
 		Versions:      ctx.Int("versions"),
-		Metadata:      ctx.Bool("extended-metadata"),
+		Metadata:      ctx.Bool("metadata"),
 		CreateObjects: ctx.Int("objects"),
 		NoPrefix:      ctx.Bool("noprefix"),
 	}

--- a/cli/put.go
+++ b/cli/put.go
@@ -91,7 +91,7 @@ func putOpts(ctx *cli.Context) minio.PutObjectOptions {
 		PartSize:             pSize,
 	}
 
-	for _, flag := range []string{"metadata", "tag"} {
+	for _, flag := range []string{"add-metadata", "tag"} {
 		values := make(map[string]string)
 
 		for _, v := range ctx.StringSlice(flag) {


### PR DESCRIPTION
after https://github.com/minio/warp/pull/349, seeing `list flag redefined: metadata` issue, thus renaming the flag name to `extended-metadata`.

relates to https://github.com/Homebrew/homebrew-core/pull/203322