### PR TITLE
Fix inconsistent output

### DIFF
--- a/cli/ui.go
+++ b/cli/ui.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"runtime/pprof"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -174,7 +175,8 @@ func (u *ui) View() string {
 		case <-time.After(time.Second):
 		}
 		if resp != nil {
-			stats := fmt.Sprintf("\nReqs: %d, Errs:%d, Objs:%d, Bytes: %d\n", resp.Total.TotalRequests, resp.Total.TotalErrors, resp.Total.TotalObjects, resp.Total.TotalBytes)
+			nBytes := strings.TrimSuffix(bench.Throughput(resp.Total.TotalBytes).String(), "/s")
+			stats := fmt.Sprintf("\nReqs: %d, Errs:%d, Objs:%d, Bytes: %s\n", resp.Total.TotalRequests, resp.Total.TotalErrors, resp.Total.TotalObjects, nBytes)
 			ops := stringKeysSorted(resp.ByOpType)
 			for _, op := range ops {
 				tp := resp.ByOpType[op].Throughput

--- a/cli/ui.go
+++ b/cli/ui.go
@@ -185,7 +185,7 @@ func (u *ui) View() string {
 				stats += fmt.Sprintf(" -%10s Average: %.0f Obj/s, %s", op, tp.ObjectsPS(), tp.BytesPS().String())
 				segs.Segments.SortByStartTime()
 				lastOps := segs.Segments[len(segs.Segments)-1]
-				if time.Since(lastOps.Start) > 5*time.Second {
+				if time.Since(lastOps.Start) > 15*time.Second {
 					stats += "\n"
 					continue
 				}

--- a/cli/ui.go
+++ b/cli/ui.go
@@ -184,14 +184,22 @@ func (u *ui) View() string {
 				if segs == nil || len(segs.Segments) == 0 {
 					continue
 				}
-				stats += fmt.Sprintf(" -%10s Average: %.0f Obj/s, %s", op, tp.ObjectsPS(), tp.BytesPS().String())
+				tpBytes := ""
+				if tp.Bytes > 0 {
+					tpBytes = ", " + tp.BytesPS().String()
+				}
+				stats += fmt.Sprintf(" -%10s Average: %.0f Obj/s%s", op, tp.ObjectsPS(), tpBytes)
 				segs.Segments.SortByStartTime()
 				lastOps := segs.Segments[len(segs.Segments)-1]
 				if time.Since(lastOps.Start) > 15*time.Second {
 					stats += "\n"
 					continue
 				}
-				stats += fmt.Sprintf("; Current %.0f Obj/s, %s", lastOps.OPS, bench.Throughput(lastOps.BPS))
+				tpBytes = ""
+				if tp.Bytes > 0 {
+					tpBytes = ", " + bench.Throughput(lastOps.BPS).String()
+				}
+				stats += fmt.Sprintf("; Current %.0f Obj/s%s", lastOps.OPS, tpBytes)
 				if len(resp.ByOpType[op].Requests) == 0 {
 					stats += ".\n"
 					continue

--- a/pkg/aggregate/collector.go
+++ b/pkg/aggregate/collector.go
@@ -60,8 +60,8 @@ func LiveCollector(ctx context.Context, updates chan UpdateReq, clientID string)
 // If the provided channel blocks no update will be sent.
 type UpdateReq struct {
 	C     chan<- *Realtime `json:"-"`
-	Reset bool             `json:"reset"`
-	Final bool             `json:"final"`
+	Reset bool             `json:"reset"` // Does not return result.
+	Final bool             `json:"final"` // Blocks until final value is ready.
 }
 
 type collector struct {

--- a/pkg/aggregate/live.go
+++ b/pkg/aggregate/live.go
@@ -430,6 +430,7 @@ func (l LiveAggregate) Report(op string, o ReportOptions) string {
 			}
 			dst.WriteByte('\n')
 		}
+		dst.WriteByte('\n')
 	}
 
 	if segs := data.Throughput.Segmented; segs != nil {

--- a/pkg/aggregate/live.go
+++ b/pkg/aggregate/live.go
@@ -723,7 +723,7 @@ func (l *liveThroughput) Add(o bench.Operation) {
 		l.segments = make([]liveSegments, 0, 100)
 		l.segmentsStart = startUnix
 	}
-	if startUnixNano < l.segmentsStart {
+	if startUnix < l.segmentsStart {
 		// Drop...
 		return
 	}

--- a/pkg/aggregate/requests.go
+++ b/pkg/aggregate/requests.go
@@ -102,8 +102,9 @@ func (a SingleSizedRequests) StringByN() string {
 		", 50%: ", fmtMillis(reqs.DurMedianMillis),
 		", 90%: ", fmtMillis(reqs.Dur90Millis),
 		", 99%: ", fmtMillis(reqs.Dur99Millis),
-		", Fastest: ", fmtMillis(reqs.FastestMillis),
-		", Slowest: ", fmtMillis(reqs.SlowestMillis),
+		// These are not accumulated.
+		", Fastest: ", fmtMillis(reqs.FastestMillis*n),
+		", Slowest: ", fmtMillis(reqs.SlowestMillis*n),
 		", StdDev: ", fmtMillis(reqs.StdDev),
 	)
 }
@@ -211,7 +212,7 @@ type RequestSizeRange struct {
 	BpsPct *[101]float64 `json:"bps_percentiles,omitempty"`
 
 	BpsMedian         float64 `json:"bps_median"`
-	AvgDurationMillis int     `json:"avg_duration_millis"`
+	AvgDurationMillis float64 `json:"avg_duration_millis"`
 
 	// Stats:
 	BpsAverage float64 `json:"bps_average"`
@@ -270,7 +271,7 @@ func (s *RequestSizeRange) fill(ss bench.SizeSegment) {
 	s.MaxSize = int(ss.Biggest)
 	s.MinSizeString, s.MaxSizeString = ss.SizesString()
 	s.AvgObjSize = int(ops.AvgSize())
-	s.AvgDurationMillis = durToMillis(ops.AvgDuration())
+	s.AvgDurationMillis = durToMillisF(ops.AvgDuration())
 	s.BpsAverage = ops.OpThroughput().Float()
 	s.BpsMedian = ops.Median(0.5).BytesPerSec().Float()
 	s.Bps90 = ops.Median(0.9).BytesPerSec().Float()

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -132,10 +132,12 @@ func (m *MixedDistribution) deleteRandomObj() generator.Object {
 	panic("ran out of objects")
 }
 
-func (m *MixedDistribution) addObj(o generator.Object) {
+func (m *MixedDistribution) addObj(o generator.Object) int {
 	m.mu.Lock()
 	m.objects[o.Name] = o
+	n := len(m.objects)
 	m.mu.Unlock()
+	return n
 }
 
 func (m *MixedDistribution) getOp() string {
@@ -209,8 +211,8 @@ func (g *Mixed) Prepare(ctx context.Context) error {
 				}
 				clDone()
 				obj.Reader = nil
-				g.Dist.addObj(*obj)
-				g.prepareProgress(float64(len(g.Dist.objects)) / float64(g.CreateObjects))
+				n := g.Dist.addObj(*obj)
+				g.prepareProgress(float64(n) / float64(g.CreateObjects))
 			}
 		}(obj)
 	}

--- a/pkg/bench/ops.go
+++ b/pkg/bench/ops.go
@@ -58,6 +58,9 @@ func (o Operation) Duration() time.Duration {
 type Throughput float64
 
 func (t Throughput) String() string {
+	if t == 0 {
+		return "0B/s"
+	}
 	if t < 2<<10 {
 		return fmt.Sprintf("%.1fB/s", float64(t))
 	}


### PR DESCRIPTION
* Fixes fluctuating request times during benchmark.
* Fix wrong min/max time on requests in report.
* Hide "current" if data is older than 15s.
* Don't show 0-byte operation throughput.
* Make byte counter neater.

Fixes:

* Race in mixed benchmark.
* Crash when operation with early start arrives.