### PR TITLE
Fix wrong obj count when doing multiobject

### DIFF
--- a/pkg/aggregate/live.go
+++ b/pkg/aggregate/live.go
@@ -33,7 +33,7 @@ import (
 	"github.com/minio/warp/pkg/bench"
 )
 
-const currentVersion = 1
+const currentVersion = 2
 
 // Realtime is a collection of realtime aggregated data.
 type Realtime struct {
@@ -800,6 +800,14 @@ func (l liveThroughput) asThroughput() Throughput {
 		t.Bytes += seg.bytes
 		t.Objects += seg.objs
 		t.Operations += seg.opsStarted
+		var reqAvg float64
+		objsPerOp := 1
+		if reqAvg > 0 {
+			reqAvg = float64(seg.reqDur) / float64(seg.opsStarted)
+		}
+		if seg.ops > 0 && seg.objs > 0 {
+			objsPerOp = int(seg.objs / seg.ops)
+		}
 		segments = append(segments, bench.Segment{
 			Start:      time.Unix(l.segmentsStart+int64(i), 0),
 			EndsBefore: time.Unix(l.segmentsStart+int64(i+1), -1),
@@ -809,11 +817,11 @@ func (l liveThroughput) asThroughput() Throughput {
 			PartialOps: seg.partialOps,
 			FullOps:    seg.fullOps,
 			OpsEnded:   seg.opsEnded,
-			Objects:    seg.ops,
+			Objects:    seg.objs,
 			Errors:     seg.errors,
-			ReqAvg:     float64(seg.reqDur) / float64(seg.opsStarted), // TODO: CHECK 0
+			ReqAvg:     reqAvg,
 			TotalBytes: int64(seg.bytes),
-			ObjsPerOp:  int(seg.objs / seg.ops),
+			ObjsPerOp:  objsPerOp,
 		})
 	}
 


### PR DESCRIPTION
Segments were counting operations and not objects.

Bumping version, but not bothering converting.

Bonus check for zeros when dividing.

before/after

```
λ go build&&warp analyze -analyze.op=list warp-list-2023-09-22[093724]-3GWn.csv.zst
16176 operations loaded... Done!

Report: LIST (6176 reqs). Ran Duration: 57s, starting 09:37:29 CEST
 * Objects per request: 100. Concurrency: 100. Hosts: 2.
 * Average: 10221.03 obj/s (57s)
 * Reqs: Avg: 981.9ms, 50%: 971.1ms, 90%: 1112.4ms, 99%: 1271.6ms, Fastest: 358.6ms, Slowest: 1545.5ms, StdDev: 103.9ms
 * TTFB: Avg: 982ms, Best: 358ms, 25th: 915ms, Median: 971ms, 75th: 1.041s, 90th: 1.112s, 99th: 1.272s, Worst: 1.545s StdDev: 104ms

Throughput by host:
 * http://127.0.0.1:9001: Avg: 5136.87 obj/s (60s)
 * http://127.0.0.1:9002: Avg: 5097.02 obj/s (60s)

Throughput, split into 57 x 1s:
 * Fastest: 111.12 obj/s (1s, starting 09:37:48 CEST)
 * 50% Median: 105.12 obj/s (1s, starting 09:38:19 CEST)
 * Slowest: 85.76 obj/s (1s, starting 09:37:35 CEST)
 
λ go build&&warp analyze -analyze.op=list warp-list-2023-09-22[093724]-3GWn.csv.zst
16176 operations loaded... Done!

Report: LIST (6176 reqs). Ran Duration: 57s, starting 09:37:29 CEST
 * Objects per request: 100. Concurrency: 100. Hosts: 2.
 * Average: 10221.03 obj/s (57s)
 * Reqs: Avg: 981.9ms, 50%: 971.1ms, 90%: 1112.4ms, 99%: 1271.6ms, Fastest: 358.6ms, Slowest: 1545.5ms, StdDev: 103.9ms
 * TTFB: Avg: 982ms, Best: 358ms, 25th: 915ms, Median: 971ms, 75th: 1.041s, 90th: 1.112s, 99th: 1.272s, Worst: 1.545s StdDev: 104ms

Throughput by host:
 * http://127.0.0.1:9001: Avg: 5136.87 obj/s (60s)
 * http://127.0.0.1:9002: Avg: 5097.02 obj/s (60s)

Throughput, split into 57 x 1s:
 * Fastest: 11112.47 obj/s (1s, starting 09:37:48 CEST)
 * 50% Median: 10511.65 obj/s (1s, starting 09:38:19 CEST)
 * Slowest: 8575.95 obj/s (1s, starting 09:37:35 CEST)
 ```
 
 Yes, the last numbers are the correct ones.