### PR TITLE
Provide aggregated data when using -serve

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -123,7 +123,7 @@ func mainAnalyze(ctx *cli.Context) error {
 	if len(args) > 1 {
 		console.Fatal("Only one benchmark file can be given")
 	}
-	monitor := api.NewBenchmarkMonitor(ctx.String(serverFlagName))
+	monitor := api.NewBenchmarkMonitor(ctx.String(serverFlagName), nil)
 	defer monitor.Done()
 	log := func(format string, data ...interface{}) {
 		console.Eraseline()
@@ -157,6 +157,7 @@ func mainAnalyze(ctx *cli.Context) error {
 				Color:   !globalNoColor,
 				OnlyOps: getAnalyzeOPS(ctx),
 			})
+			monitor.UpdateAggregate(&final, "")
 			if globalJSON {
 				b, err := json.MarshalIndent(final, "", "  ")
 				fatalIf(probe.NewError(err), "Unable to parse input")

--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -92,6 +92,16 @@ var benchFlags = []cli.Flag{
 		EnvVar: "",
 		Value:  "",
 	},
+	cli.StringSliceFlag{
+		Name:   "add-metadata",
+		Usage:  "Add user metadata to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --add-metadata foo=bar --add-metadata randomValue=rand:1024.",
+		Hidden: true,
+	},
+	cli.StringSliceFlag{
+		Name:   "tag",
+		Usage:  "Add user tag to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --tag foo=bar --tag randomValue=rand:1024.",
+		Hidden: true,
+	},
 }
 
 // runBench will run the supplied benchmark and save/print the analysis.
@@ -122,7 +132,7 @@ func runBench(ctx *cli.Context, b bench.Benchmark) error {
 	retrieveOps, updates := addCollector(ctx, b)
 	c.UpdateStatus = ui.SetSubText
 
-	monitor := api.NewBenchmarkMonitor(ctx.String(serverFlagName))
+	monitor := api.NewBenchmarkMonitor(ctx.String(serverFlagName), updates)
 	monitor.SetLnLoggers(func(data ...interface{}) {
 		ui.SetSubText(strings.TrimRight(fmt.Sprintln(data...), "\r\n."))
 	}, printError)
@@ -258,6 +268,7 @@ func runBench(ctx *cli.Context, b bench.Benchmark) error {
 			OnlyOps: getAnalyzeOPS(ctx),
 		})
 
+		monitor.UpdateAggregate(final, fileName)
 		ui.Update(tea.Quit())
 		ui.Wait()
 		fmt.Println("")

--- a/cli/benchserver.go
+++ b/cli/benchserver.go
@@ -119,7 +119,7 @@ func runServerBenchmark(ctx *cli.Context, b bench.Benchmark) (bool, error) {
 	conns.info = infoLn
 	conns.errLn = printError
 	defer conns.closeAll()
-	monitor := api.NewBenchmarkMonitor(ctx.String(serverFlagName))
+	monitor := api.NewBenchmarkMonitor(ctx.String(serverFlagName), nil)
 	monitor.SetLnLoggers(infoLn, printError)
 	defer monitor.Done()
 	errorLn := printError
@@ -215,6 +215,7 @@ func runServerBenchmark(ctx *cli.Context, b bench.Benchmark) (bool, error) {
 	var updates chan aggregate.UpdateReq
 	if !ctx.Bool("full") {
 		updates = make(chan aggregate.UpdateReq, 10)
+		monitor.SetUpdate(updates)
 	}
 	prof, err := startProfiling(context.Background(), ctx)
 	if err != nil {
@@ -320,6 +321,7 @@ func runServerBenchmark(ctx *cli.Context, b bench.Benchmark) (bool, error) {
 			Color:   !globalNoColor,
 			OnlyOps: getAnalyzeOPS(ctx),
 		})
+		monitor.UpdateAggregate(&final, fileName)
 		ui.Update(tea.Quit())
 		ui.Wait()
 		fmt.Println("")

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -279,16 +279,6 @@ var ioFlags = []cli.Flag{
 		Name:  "lookup",
 		Usage: "Force requests to be 'host' for host-style or 'path' for path-style lookup. Default will attempt autodetect based on remote host name.",
 	},
-	cli.StringSliceFlag{
-		Name:   "add-metadata",
-		Usage:  "Add user metadata to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --add-metadata foo=bar --add-metadata randomValue=rand:1024.",
-		Hidden: true,
-	},
-	cli.StringSliceFlag{
-		Name:   "tag",
-		Usage:  "Add user tag to all objects using the format <key>=<value>. Random value can be set with 'rand:%length'. Can be used multiple times. Example: --tag foo=bar --tag randomValue=rand:1024.",
-		Hidden: true,
-	},
 }
 
 func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {

--- a/pkg/aggregate/live.go
+++ b/pkg/aggregate/live.go
@@ -685,7 +685,7 @@ func Live(ops <-chan bench.Operation, updates chan UpdateReq, clientID string) *
 		}()
 		wg.Wait()
 		if updates != nil && time.Since(lastUpdate) > time.Second {
-			u := Realtime{Total: a.Total.Update(), ByOpType: make(map[string]*LiveAggregate, len(a.ByOpType))}
+			u := Realtime{Total: a.Total.Update(), ByOpType: make(map[string]*LiveAggregate, len(a.ByOpType)), DataVersion: currentVersion}
 			for k, v := range a.ByOpType {
 				if v != nil {
 					clone := v.Update()


### PR DESCRIPTION
Add updates and final value to status calls.
This will allow querying while benchmark is running and finalized.

Test by adding `-serve=:8080`

Progress can be monitored on `http://127.0.0.1:8080/v1/status`, which includes aggregated data.

`http://127.0.0.1:8080/v1/operations` will also prove access to the `.json.zst` file.

Unless using -full `/v1/aggregated` will return 404 and `/v1/operations/json` will return nothing.
