### PR TITLE
Add aggregated format compare

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -120,9 +120,6 @@ func mainAnalyze(ctx *cli.Context) error {
 	if len(args) == 0 {
 		console.Fatal("No benchmark data file supplied")
 	}
-	if len(args) > 1 {
-		console.Fatal("Only one benchmark file can be given")
-	}
 	monitor := api.NewBenchmarkMonitor(ctx.String(serverFlagName), nil)
 	defer monitor.Done()
 	log := func(format string, data ...interface{}) {

--- a/pkg/aggregate/compare.go
+++ b/pkg/aggregate/compare.go
@@ -1,0 +1,129 @@
+/*
+ * Warp (C) 2019-2025 MinIO, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aggregate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/minio/warp/pkg/bench"
+)
+
+func Compare(before, after *LiveAggregate, op string) (*bench.Comparison, error) {
+	var res bench.Comparison
+
+	if before.TotalErrors > 0 || after.TotalErrors > 0 {
+		return nil, fmt.Errorf("errors recorded in benchmark run. before: %v, after %d", before.TotalErrors, after.TotalErrors)
+	}
+	if after.Throughput.Segmented.Segments == nil || before.Throughput.Segmented.Segments == nil {
+		return nil, fmt.Errorf("no segments found in benchmark run. before: %v, after %v", before.Throughput.Segmented.Segments, after.Throughput.Segmented.Segments)
+	}
+	res.Op = op
+	as := after.Throughput.Segmented.Segments
+	aDur := time.Duration(after.Throughput.Segmented.SegmentDurationMillis) * time.Millisecond
+	bDur := time.Duration(after.Throughput.Segmented.SegmentDurationMillis) * time.Millisecond
+	bs := before.Throughput.Segmented.Segments
+	as.SortByObjsPerSec()
+	bs.SortByObjsPerSec()
+	res.Median.Compare(bs.Median(0.5).LongSeg(bDur), as.Median(0.5).LongSeg(aDur))
+	res.Slowest.Compare(bs.Median(0.0).LongSeg(bDur), as.Median(0.0).LongSeg(aDur))
+	res.Fastest.Compare(bs.Median(1).LongSeg(bDur), as.Median(1).LongSeg(aDur))
+
+	beforeTotals := bench.Segment{
+		EndsBefore: before.EndTime,
+		Start:      before.StartTime,
+		OpType:     op,
+		Host:       "",
+		OpsStarted: before.TotalRequests,
+		PartialOps: 0,
+		FullOps:    before.TotalObjects,
+		OpsEnded:   before.TotalRequests,
+		Objects:    float64(before.TotalObjects),
+		Errors:     before.TotalErrors,
+		ReqAvg:     float64(before.TotalRequests),
+		TotalBytes: before.TotalBytes,
+		ObjsPerOp:  before.TotalObjects / before.TotalRequests,
+	}
+
+	afterTotals := bench.Segment{
+		EndsBefore: after.EndTime,
+		Start:      after.StartTime,
+		OpType:     op,
+		Host:       "",
+		OpsStarted: after.TotalRequests,
+		PartialOps: 0,
+		FullOps:    after.TotalObjects,
+		OpsEnded:   after.TotalRequests,
+		Objects:    float64(after.TotalObjects),
+		Errors:     after.TotalErrors,
+		ReqAvg:     float64(after.TotalRequests),
+		TotalBytes: after.TotalBytes,
+		ObjsPerOp:  after.TotalObjects / after.TotalRequests,
+	}
+	res.Average.Compare(beforeTotals, afterTotals)
+
+	if after.Requests != nil && before.Requests != nil {
+		a, _ := mergeRequests(after.Requests)
+		b, _ := mergeRequests(before.Requests)
+		// TODO: Do multisized?
+		if a.Requests > 0 || b.Requests > 0 {
+			ms := float64(time.Millisecond)
+			const round = 100 * time.Microsecond
+			aInv := 1.0 / max(1, float64(a.MergedEntries))
+			bInv := 1.0 / max(1, float64(b.MergedEntries))
+			res.Reqs.CmpRequests = bench.CmpRequests{
+				AvgObjSize: a.ObjSize/int64(a.MergedEntries) - b.ObjSize/int64(b.MergedEntries),
+				Requests:   a.Requests - b.Requests,
+				Average:    time.Duration((a.DurAvgMillis*aInv - b.DurMedianMillis*bInv) * ms).Round(round),
+				Worst:      time.Duration((a.SlowestMillis - b.SlowestMillis) * ms).Round(round),
+				Best:       time.Duration((a.FastestMillis - b.FastestMillis) * ms).Round(round),
+				Median:     time.Duration((a.DurMedianMillis*aInv - b.DurMedianMillis*bInv) * ms).Round(round),
+				P90:        time.Duration((a.Dur90Millis*aInv - b.Dur90Millis*bInv) * ms).Round(round),
+				P99:        time.Duration((a.Dur99Millis*aInv - b.Dur99Millis*bInv) * ms).Round(round),
+				StdDev:     time.Duration((a.StdDev*aInv - b.StdDev*bInv) * ms).Round(round),
+			}
+			res.Reqs.Before = bench.CmpRequests{
+				AvgObjSize: b.ObjSize / int64(b.MergedEntries),
+				Requests:   b.Requests,
+				Average:    time.Duration(b.DurAvgMillis * bInv * ms).Round(round),
+				Worst:      time.Duration(b.SlowestMillis * ms).Round(round),
+				Best:       time.Duration(b.FastestMillis * ms).Round(round),
+				Median:     time.Duration(b.DurMedianMillis * bInv * ms).Round(round),
+				P90:        time.Duration(b.Dur90Millis * bInv * ms).Round(round),
+				P99:        time.Duration(b.Dur99Millis * bInv * ms).Round(round),
+				StdDev:     time.Duration(b.StdDev * bInv * ms).Round(round),
+			}
+			res.Reqs.After = bench.CmpRequests{
+				AvgObjSize: a.ObjSize / int64(a.MergedEntries),
+				Requests:   a.Requests,
+				Average:    time.Duration(a.DurAvgMillis * aInv * ms).Round(round),
+				Worst:      time.Duration(a.SlowestMillis * ms).Round(round),
+				Best:       time.Duration(a.FastestMillis * ms).Round(round),
+				Median:     time.Duration(a.DurMedianMillis * aInv * ms).Round(round),
+				P90:        time.Duration(a.Dur90Millis * aInv * ms).Round(round),
+				P99:        time.Duration(a.Dur99Millis * aInv * ms).Round(round),
+				StdDev:     time.Duration(a.StdDev * aInv * ms).Round(round),
+			}
+			if a.FirstByte != nil && b.FirstByte != nil {
+				res.TTFB = b.FirstByte.AsBench(b.MergedEntries).Compare(a.FirstByte.AsBench(a.MergedEntries))
+			}
+		}
+	}
+
+	return &res, nil
+}

--- a/pkg/aggregate/throughput.go
+++ b/pkg/aggregate/throughput.go
@@ -286,6 +286,16 @@ func cloneBenchSegments(s bench.Segments) []SegmentSmall {
 	return res
 }
 
+func (s SegmentSmall) LongSeg(segdur time.Duration) bench.Segment {
+	return bench.Segment{
+		Start:      s.Start,
+		EndsBefore: s.Start.Add(segdur),
+		TotalBytes: int64(time.Duration(s.BPS) * segdur / time.Second),
+		Objects:    s.OPS,
+		Errors:     s.Errors,
+	}
+}
+
 func (s *SegmentSmall) add(other SegmentSmall) SegmentSmall {
 	s.Errors += other.Errors
 	s.OPS += other.OPS

--- a/pkg/bench/compare.go
+++ b/pkg/bench/compare.go
@@ -59,8 +59,6 @@ func (c *CmpReqs) Compare(before, after Operations) {
 		Worst:   a.Worst - b.Worst,
 		Best:    a.Best - b.Best,
 		Median:  a.Median - b.Median,
-		P25:     a.P25 - b.P25,
-		P75:     a.P75 - b.P75,
 		P90:     a.P90 - b.P90,
 		P99:     a.P99 - b.P99,
 		StdDev:  a.StdDev - b.StdDev,
@@ -72,9 +70,7 @@ type CmpRequests struct {
 	Requests   int
 	Average    time.Duration
 	Best       time.Duration
-	P25        time.Duration
 	Median     time.Duration
-	P75        time.Duration
 	P90        time.Duration
 	P99        time.Duration
 	Worst      time.Duration
@@ -87,9 +83,7 @@ func (c *CmpRequests) fill(ops Operations) {
 	c.AvgObjSize = ops.AvgSize()
 	c.Average = ops.AvgDuration()
 	c.Best = ops.Median(0).Duration()
-	c.P25 = ops.Median(0.25).Duration()
 	c.Median = ops.Median(0.5).Duration()
-	c.P75 = ops.Median(0.75).Duration()
 	c.P90 = ops.Median(0.9).Duration()
 	c.P99 = ops.Median(0.99).Duration()
 	c.Worst = ops.Median(1).Duration()
@@ -241,7 +235,6 @@ func plusPositiveD(d time.Duration) string {
 	}
 }
 
-// Compare compares operations of a single operation type.
 func Compare(before, after Operations, analysis time.Duration, allThreads bool) (*Comparison, error) {
 	var res Comparison
 	if before.FirstOpType() != after.FirstOpType() {


### PR DESCRIPTION
Usage: warp cmp before.jzon.zst after.json.zst`.

Example...

```
λ warp cmp warp-mixed-2025-04-22[151603]-BTJN.json.zst warp-mixed-2025-04-22[135713]-6t7p.json.zst

-------------------
Operation: DELETE
Operations: 812 -> 2232
Duration: 31s -> 1m34s
* Average: -8.93% (-2.3) obj/s
* Requests: Avg: +31.2ms (+9%), P50: +15.9ms (+12%), P99: +37.6ms (+10%), Best: -12.3ms (-79%), Worst: +58.8ms (+12%) StdDev: +5.5ms (+6%)
-------------------
Operation: GET
Operations: 3651 -> 10024
Duration: 31s -> 1m34s
* Average: -9.00% (-105.3 MiB/s) throughput, -9.00% (-10.5) obj/s
* Requests: Avg: +2.5ms (+5%), P50: +900µs (+3%), P99: +1.1ms (+2%), Best: -2.2ms (-22%), Worst: +81.1ms (+51%) StdDev: +1.9ms (+21%)
* TTFB: Avg: +1.5ms (+20%), P50: +415.655µs (+7%), P99: +2.007334ms (+4%), Best: -499.8µs (-24%), Worst: +78.9896ms (+54%) StdDev: +2.069452ms (+27%)
-------------------
Operation: PUT
Operations: 1219 -> 3351
Duration: 31s -> 1m34s
* Average: -8.84% (-34.5 MiB/s) throughput, -8.84% (-3.4) obj/s
* Requests: Avg: +44.3ms (+13%), P50: +43.2ms (+13%), P99: +65.5ms (+11%), Best: +4.6ms (+7%), Worst: +107.2ms (+16%) StdDev: +13.1ms (+12%)
-------------------
Operation: STAT
Operations: 2442 -> 6685
Duration: 31s -> 1m34s
* Average: -9.31% (-7.3) obj/s
* Requests: Avg: +1.3ms (+3%), P50: -100µs (-4%), P99: -200µs (-1%), Best: 0s (0%), Worst: +26.4ms (+35%) StdDev: +100µs (+2%)

λ
```