### PR TITLE
Add optional checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,10 @@ It is possible by forcing md5 checksums on data by using the `--md5` option.
 
 To test [POST Object](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html) operations use `-post` parameter.
 
+To add a [checksum](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html) to the uploaded objects, use `--checksum` parameter.
+The following checksums are supported: `CRC32` (composite), `CRC32-FO` (full object), `CRC32C`, `CRC32-FO`, `CRC32C`, `SHA1`, `SHA256` and `CRC64NVME`.
+Adding a checksum will always disable MD5 checksums.
+
 ## DELETE
 
 Benchmarking delete operations will attempt to delete as many objects it can within `--duration`.

--- a/cli/client.go
+++ b/cli/client.go
@@ -175,12 +175,13 @@ func getClient(ctx *cli.Context, host string) (*minio.Client, error) {
 		lookup = minio.BucketLookupPath
 	}
 	cl, err := minio.New(host, &minio.Options{
-		Creds:        creds,
-		Secure:       ctx.Bool("tls"),
-		Region:       ctx.String("region"),
-		BucketLookup: lookup,
-		CustomMD5:    md5simd.NewServer().NewHash,
-		Transport:    transport,
+		Creds:           creds,
+		Secure:          ctx.Bool("tls"),
+		Region:          ctx.String("region"),
+		BucketLookup:    lookup,
+		CustomMD5:       md5simd.NewServer().NewHash,
+		Transport:       transport,
+		TrailingHeaders: useTrailingHeaders.Load(),
 	})
 	if err != nil {
 		return nil, err

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -331,14 +331,15 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 		// set burst to 1 as limiter will always be called to wait for 1 token
 		rpsLimiter = rate.NewLimiter(rate.Limit(rpsLimit), 1)
 	}
-
+	// Create put options now, so ensure that trailing headers are set.
+	putOpts := putOpts(ctx)
 	return bench.Common{
 		Client:        newClient(ctx),
 		Concurrency:   ctx.Int("concurrent"),
 		Source:        src,
 		Bucket:        ctx.String("bucket"),
 		Location:      ctx.String("region"),
-		PutOpts:       putOpts(ctx),
+		PutOpts:       putOpts,
 		DiscardOutput: noOps,
 		ExtraOut:      extra,
 		RpsLimiter:    rpsLimiter,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.3
 require (
 	github.com/bygui86/multi-profile/v2 v2.1.0
 	github.com/charmbracelet/bubbles v0.21.0
-	github.com/charmbracelet/bubbletea v1.3.4
+	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/cheggaaa/pb v1.0.29
 	github.com/dustin/go-humanize v1.0.1
@@ -19,7 +19,7 @@ require (
 	github.com/minio/madmin-go/v4 v4.0.13
 	github.com/minio/mc v0.0.0-20250506164133-19d87ba47505
 	github.com/minio/md5-simd v1.1.2
-	github.com/minio/minio-go/v7 v7.0.92-0.20250515110726-4f25bfc12706
+	github.com/minio/minio-go/v7 v7.0.92
 	github.com/minio/pkg/v3 v3.1.8
 	github.com/minio/websocket v1.6.0
 	github.com/muesli/termenv v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
 github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
-github.com/charmbracelet/bubbletea v1.3.4 h1:kCg7B+jSCFPLYRA52SDZjr51kG/fMUEoPoZrkaDHyoI=
-github.com/charmbracelet/bubbletea v1.3.4/go.mod h1:dtcUCyCGEX3g9tosuYiut3MXgY/Jsv9nKVdibKKRRXo=
+github.com/charmbracelet/bubbletea v1.3.5 h1:JAMNLTbqMOhSwoELIr0qyP4VidFq72/6E9j7HHmRKQc=
+github.com/charmbracelet/bubbletea v1.3.5/go.mod h1:TkCnmH+aBd4LrXhXcqrKiYwRs7qyQx5rBgH5fVY3v54=
 github.com/charmbracelet/colorprofile v0.3.1 h1:k8dTHMd7fgw4bnFd7jXTLZrSU/CQrKnL3m+AxCzDz40=
 github.com/charmbracelet/colorprofile v0.3.1/go.mod h1:/GkGusxNs8VB/RSOh3fu0TJmQ4ICMMPApIIVn0KszZ0=
 github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
@@ -119,8 +119,8 @@ github.com/minio/mc v0.0.0-20250506164133-19d87ba47505 h1:zPiINQs+HwJUyiSNynfyAo
 github.com/minio/mc v0.0.0-20250506164133-19d87ba47505/go.mod h1:u2sfW0ODOs2EGYdRlh9YjVdJ6VjB4GwIYA82Bl/bmAU=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
-github.com/minio/minio-go/v7 v7.0.92-0.20250515110726-4f25bfc12706 h1:Tj9KPjo+7+s20m/tJYlwV/7qQdU8of2ROQ7bEdeNgIo=
-github.com/minio/minio-go/v7 v7.0.92-0.20250515110726-4f25bfc12706/go.mod h1:vTIc8DNcnAZIhyFsk8EB90AbPjj3j68aWIEQCiPj7d0=
+github.com/minio/minio-go/v7 v7.0.92 h1:jpBFWyRS3p8P/9tsRc+NuvqoFi7qAmTCFPoRFmobbVw=
+github.com/minio/minio-go/v7 v7.0.92/go.mod h1:vTIc8DNcnAZIhyFsk8EB90AbPjj3j68aWIEQCiPj7d0=
 github.com/minio/mux v1.9.0 h1:dWafQFyEfGhJvK6AwLOt83bIG5bxKxKJnKMCi0XAaoA=
 github.com/minio/mux v1.9.0/go.mod h1:1pAare17ZRL5GpmNL+9YmqHoWnLmMZF9C/ioUCfy0BQ=
 github.com/minio/pkg/v3 v3.1.8 h1:mcnJod5IvEUtk9KjincKB2e1IJJXcSHnZ+LxhFMeqlk=


### PR DESCRIPTION
Usage is similar to [mc](https://github.com/minio/mc/pull/5043).

> To add a [checksum](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html) to the uploaded objects, use `--checksum` parameter.
The following checksums are supported: `CRC32` (composite), `CRC32-FO` (full object), `CRC32C`, `CRC32-FO`, `CRC32C`, `SHA1`, `SHA256` and `CRC64NVME`. Adding a checksum will always disable MD5 checksums.