### PR TITLE
fix: unaligned 64-bit atomic operation on 32-bit archs

### DIFF
--- a/pkg/generator/random.go
+++ b/pkg/generator/random.go
@@ -81,7 +81,7 @@ type randomSrc struct {
 	rng     *rand.Rand
 	obj     Object
 	o       Options
-	counter uint64
+	counter atomic.Uint64
 }
 
 func newRandom(o Options) (Source, error) {
@@ -118,11 +118,11 @@ func newRandom(o Options) (Source, error) {
 }
 
 func (r *randomSrc) Object() *Object {
-	atomic.AddUint64(&r.counter, 1)
+	n := r.counter.Add(1)
 	var nBuf [16]byte
 	randASCIIBytes(nBuf[:], r.rng)
 	r.obj.Size = r.o.getSize(r.rng)
-	r.obj.setName(fmt.Sprintf("%d.%s.rnd", atomic.LoadUint64(&r.counter), string(nBuf[:])))
+	r.obj.setName(fmt.Sprintf("%d.%s.rnd", n, string(nBuf[:])))
 
 	// Reset scrambler
 	r.source.ResetSize(r.obj.Size)


### PR DESCRIPTION
On 32-bit architectures (e.g. 386, ARM) TestNew was panicking with: 
```
--- FAIL: TestNew (0.00s)
    --- FAIL: TestNew/Default (0.00s)
panic: unaligned 64-bit atomic operation [recovered, repanicked]

goroutine 7 [running]:
testing.tRunner.func1.2({0x5e1fcc20, 0x5e221028})
        testing/testing.go:1872 +0x2b5
testing.tRunner.func1()
        testing/testing.go:1875 +0x48a
panic({0x5e1fcc20, 0x5e221028})
        runtime/panic.go:783 +0x120
internal/runtime/atomic.panicUnaligned()
        internal/runtime/atomic/unaligned.go:8 +0x38
internal/runtime/atomic.Xadd64(0x5e92636c, 0x1)
        internal/runtime/atomic/atomic_386.s:127 +0x11
github.com/minio/warp/pkg/generator.(*randomSrc).Object(0x5e926300)
        github.com/minio/warp/pkg/generator/random.go:121 +0x49
github.com/minio/warp/pkg/generator.TestNew.func1(0x5e807688)
        github.com/minio/warp/pkg/generator/generator_test.go:60 +0x149
testing.tRunner(0x5e807688, 0x5e816840)
        testing/testing.go:1934 +0x164
created by testing.(*T).Run in goroutine 6
        testing/testing.go:1997 +0x55a
FAIL    github.com/minio/warp/pkg/generator     0.006s
FAIL
```

`randomSrc.counter` (uint64) was placed after fields whose alignment is 4 bytes, so on 32-bit platforms it could reside at a 4-byte offset. sync/atomic [requires](https://pkg.go.dev/sync/atomic#pkg-note-BUG) 64-bit values to be 8-byte aligned on 32-bit systems; the runtime detects and panics on unaligned `atomic.AddUint64`.

This PR switches `randomSrc` to use an `atomic.Uint64` instead.