### PR TITLE
fix: fatal errors break the terminal due to incorrect bubble tea shutdown

### DIFF
--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -126,6 +126,7 @@ func runBench(ctx *cli.Context, b bench.Benchmark) error {
 	}
 	var ui ui
 	if !globalQuiet && !globalJSON {
+		registerUI(&ui)
 		go ui.Run()
 	}
 
@@ -289,6 +290,7 @@ func runBench(ctx *cli.Context, b bench.Benchmark) error {
 	}
 	monitor.InfoLn("Cleanup Done.")
 	ui.Wait()
+	registerUI(nil)
 	return nil
 }
 


### PR DESCRIPTION
Make the correct ui.Wait() call when exiting on a fatal log, to prevent the terminal cursor from disappearing, as well as other problems that make the terminal unusable:

Before:

<img width="1564" height="468" alt="Screenshot 2025-10-07 at 15 49 35" src="https://github.com/user-attachments/assets/98d82080-df8c-41d6-abc6-46617d417438" />

After:

<img width="1562" height="345" alt="Screenshot 2025-10-07 at 15 49 59" src="https://github.com/user-attachments/assets/3f811b73-2041-45f8-a022-753852531042" />
