### PR TITLE
Highlight the danger of data being cleaned

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ By default operations are performed on a bucket called `warp-benchmark-bucket`.
 This can be changed using the `--bucket` parameter. 
 
 > [!WARNING]
-> Do however note that the bucket will be completely cleaned before and after each run, so it should **not** contain any data.
+> Note the bucket will be *completely wiped* before and after each run, so it should **not** contain any data.
 
 If you are [running TLS](https://docs.min.io/docs/how-to-secure-access-to-minio-server-with-tls.html), 
 you can enable [server-side-encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) 


### PR DESCRIPTION
I made a big mistake locally, that I suspect others might fall victim to. As such, I propose to highlight the danger of data being wiped with the warning-format. If that is to bold, then I suggest the note variant. Either way, I would argue something needs to be done to warn users of potential data loss, and not in the form of a last sentence in an arbitrary paragraph with an italicized "not".