### PR TITLE
Allow deletion with GCS (new --single-delete flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ To use [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServe
 
 If your server is incompatible with [AWS v4 signatures](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) the older v2 signatures can be used with `--signature=S3V2`.
 
+If your server doesn't support bulk object deletes (e.g. Google Cloud Storage), the `--single-delete` flag will force all object delete operations to be done one at a time.
+
 # Usage
 
 `λ warp command [options]`
@@ -387,6 +389,7 @@ Benchmarking delete operations will attempt to delete as many objects it can wit
 By default, `--objects` objects of size `--obj.size` are uploaded before doing the actual bench.
 
 The delete operations are done in `--batch` objects per request in `--concurrent` concurrently running requests.
+If `--single-delete` is specified, delete operations will be done one at a time, ignoring any `--batch` value.
 
 If there are no more objects left the benchmark will end.
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -295,6 +295,11 @@ var ioFlags = []cli.Flag{
 		Usage: "Add checksum to uploaded object. Values: CRC64NVME, CRC32[-FO], CRC32C[-FO], SHA1 or SHA256. Requires server trailing headers (AWS, MinIO)",
 		Value: "",
 	},
+	cli.BoolFlag{
+		Name:   "single-delete",
+		Usage:  "Delete objects one at a time instead of using bulk delete",
+		Hidden: true,
+	},
 }
 
 func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
@@ -355,5 +360,6 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 		RpsLimiter:    rpsLimiter,
 		Transport:     clientTransport(ctx),
 		UpdateStatus:  statusln,
+		SingleDelete:  ctx.Bool("single-delete"),
 	}
 }


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

This patch provides a new flag, --single-delete, which allows Warp deletion to work against GCS.  The flag makes all object deletions be single-object requests.

Without specifing the new flag, deletion behavior is unchanged.

## Motivation and Context

The GCS S3 compatibility API doesn't support a bulk delete command.  This patch allows Warp to be used against GCS.

NOTE: I think detecting when GCS is being targeted is outside the scope of a benchmark tool, so that is not included.

This is another tomAto/tomAHto bug/feature patch.  Is it a bug that Warp doesn't work with GCS, or is being able to target GCS a new feature?

I'm happy to change the flag name--I'm not wedded to "--single-delete".

## How to test this PR?

Any deletes except the ones in the mixed workload (which already only use single-object deletes) will fail against GCS.  With the patch and the new option, they succeed fine using single-object delete requests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [x] Internal documentation updated (README)
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)