### PR TITLE
Fix get to allow --objects 0 (per README)

### DIFF
--- a/cli/get.go
+++ b/cli/get.go
@@ -119,8 +119,14 @@ func checkGetSyntax(ctx *cli.Context) {
 	if ctx.Int("versions") < 1 {
 		console.Fatal("At least one version must be tested")
 	}
-	if ctx.Int("objects") < 1 {
-		console.Fatal("At least one object must be tested")
+	if ctx.Bool("list-existing") {
+		if ctx.Int("objects") < 0 {
+			console.Fatal("Object count must be 0 or greater")
+		}
+	} else {
+		if ctx.Int("objects") < 1 {
+			console.Fatal("At least one object must be tested")
+		}
 	}
 	checkAnalyze(ctx)
 	checkBenchmark(ctx)


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description


This fix allows --objects 0 with --list-existing while ensuring the object count is >= 1 without --list-existing and still not negative when --list-existing is supplied.

## Motivation and Context

    Using `--list-existing` will list at most `--objects` from the
    bucket and download them instead of uploading random objects
    (set it to 0 to use all object from the listing).

The intent of --objects with --list-existing for the "get" command was for the special value 0 to represent "list all and use all".  This is correctly implemented for "delete" but "get" was disallowing this combination.

## How to test this PR?

Ensure there's some objects in the specified bucket and run "warp get" with --list-existing and --objects 0.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (9e01ed3b91f882d1110a09e83a9a7a57764f8905)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)