### PR TITLE
Refactor --list-existing object listing logic

### DIFF
--- a/pkg/bench/benchmark.go
+++ b/pkg/bench/benchmark.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -265,6 +266,95 @@ func (c *Common) rpsLimit(ctx context.Context) error {
 	}
 
 	return c.RpsLimiter.Wait(ctx)
+}
+
+// ListObjectsConfig configures behavior for listing existing objects.
+type ListObjectsConfig struct {
+	Bucket         string
+	Prefix         string
+	ListFlat       bool
+	CreateObjects  int
+	FilterZeroSize bool
+	HandleVersions bool
+	MaxVersions    int
+	Shuffle        bool
+}
+
+// listExistingObjects lists objects from the bucket based on the provided configuration.
+func (c *Common) listExistingObjects(ctx context.Context, cfg ListObjectsConfig) (generator.Objects, error) {
+	cl, done := c.Client()
+	defer done()
+
+	// Ensure the bucket exists
+	found, err := cl.BucketExists(ctx, cfg.Bucket)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("bucket %s does not exist and --list-existing has been set", cfg.Bucket)
+	}
+
+	var objects generator.Objects
+	versions := map[string]int{}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	objectCh := cl.ListObjects(ctx, cfg.Bucket, minio.ListObjectsOptions{
+		WithVersions: cfg.HandleVersions,
+		Prefix:       cfg.Prefix,
+		Recursive:    !cfg.ListFlat,
+	})
+
+	for object := range objectCh {
+		if object.Err != nil {
+			return nil, object.Err
+		}
+
+		// Filter zero-size objects if configured
+		if cfg.FilterZeroSize && object.Size == 0 {
+			continue
+		}
+
+		obj := generator.Object{
+			Name: object.Key,
+			Size: object.Size,
+		}
+
+		// Handle versions if configured
+		if cfg.HandleVersions {
+			if object.VersionID == "" {
+				continue
+			}
+
+			if version, found := versions[object.Key]; found {
+				if version >= cfg.MaxVersions {
+					continue
+				}
+			}
+			versions[object.Key]++
+			obj.VersionID = object.VersionID
+		}
+
+		objects = append(objects, obj)
+
+		// Limit to CreateObjects
+		if cfg.CreateObjects > 0 && len(objects) >= cfg.CreateObjects {
+			break
+		}
+	}
+
+	if len(objects) == 0 {
+		return nil, fmt.Errorf("no objects found for bucket %s", cfg.Bucket)
+	}
+
+	// Shuffle objects if configured
+	if cfg.Shuffle {
+		rand.Shuffle(len(objects), func(i, j int) {
+			objects[i], objects[j] = objects[j], objects[i]
+		})
+	}
+
+	return objects, nil
 }
 
 func splitObjs(objects, concurrency int) [][]struct{} {

--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -48,52 +48,17 @@ func (d *Delete) Prepare(ctx context.Context) error {
 
 	// prepare the bench by listing object from the bucket
 	if d.ListExisting {
-		cl, done := d.Client()
-
-		// ensure the bucket exist
-		found, err := cl.BucketExists(ctx, d.Bucket)
+		objects, err := d.listExistingObjects(ctx, ListObjectsConfig{
+			Bucket:        d.Bucket,
+			Prefix:        d.ListPrefix,
+			ListFlat:      d.ListFlat,
+			CreateObjects: d.CreateObjects,
+			Shuffle:       true,
+		})
 		if err != nil {
 			return err
 		}
-		if !found {
-			return fmt.Errorf("bucket %s does not exist and --list-existing has been set", d.Bucket)
-		}
-
-		// list all objects
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		objectCh := cl.ListObjects(ctx, d.Bucket, minio.ListObjectsOptions{
-			Prefix:    d.ListPrefix,
-			Recursive: !d.ListFlat,
-		})
-
-		for object := range objectCh {
-			if object.Err != nil {
-				return object.Err
-			}
-			obj := generator.Object{
-				Name: object.Key,
-				Size: object.Size,
-			}
-
-			d.objects = append(d.objects, obj)
-
-			// limit to ListingMaxObjects
-			if d.CreateObjects > 0 && len(d.objects) >= d.CreateObjects {
-				break
-			}
-		}
-		if len(d.objects) == 0 {
-			return (fmt.Errorf("no objects found for bucket %s", d.Bucket))
-		}
-		done()
-
-		// Shuffle objects.
-		// Benchmark will pick from slice in order.
-		a := d.objects
-		rand.Shuffle(len(a), func(i, j int) {
-			a[i], a[j] = a[j], a[i]
-		})
+		d.objects = objects
 		return groupErr
 	}
 

--- a/pkg/bench/get.go
+++ b/pkg/bench/get.go
@@ -52,65 +52,19 @@ type Get struct {
 func (g *Get) Prepare(ctx context.Context) error {
 	// prepare the bench by listing object from the bucket
 	if g.ListExisting {
-		cl, done := g.Client()
-
-		// ensure the bucket exist
-		found, err := cl.BucketExists(ctx, g.Bucket)
+		objects, err := g.listExistingObjects(ctx, ListObjectsConfig{
+			Bucket:         g.Bucket,
+			Prefix:         g.ListPrefix,
+			ListFlat:       g.ListFlat,
+			CreateObjects:  g.CreateObjects,
+			FilterZeroSize: true,
+			HandleVersions: g.Versions > 1,
+			MaxVersions:    g.Versions,
+		})
 		if err != nil {
 			return err
 		}
-		if !found {
-			return (fmt.Errorf("bucket %s does not exist and --list-existing has been set", g.Bucket))
-		}
-
-		// list all objects
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		objectCh := cl.ListObjects(ctx, g.Bucket, minio.ListObjectsOptions{
-			WithVersions: g.Versions > 1,
-			Prefix:       g.ListPrefix,
-			Recursive:    !g.ListFlat,
-		})
-
-		versions := map[string]int{}
-
-		for object := range objectCh {
-			if object.Err != nil {
-				return object.Err
-			}
-			if object.Size == 0 {
-				continue
-			}
-			obj := generator.Object{
-				Name: object.Key,
-				Size: object.Size,
-			}
-
-			if g.Versions > 1 {
-				if object.VersionID == "" {
-					continue
-				}
-
-				if version, found := versions[object.Key]; found {
-					if version >= g.Versions {
-						continue
-					}
-				}
-				versions[object.Key]++
-				obj.VersionID = object.VersionID
-			}
-
-			g.objects = append(g.objects, obj)
-
-			// limit to ListingMaxObjects
-			if g.CreateObjects > 0 && len(g.objects) >= g.CreateObjects {
-				break
-			}
-		}
-		if len(g.objects) == 0 {
-			return (fmt.Errorf("no objects found for bucket %s", g.Bucket))
-		}
-		done()
+		g.objects = objects
 		return nil
 	}
 

--- a/pkg/bench/stat.go
+++ b/pkg/bench/stat.go
@@ -50,65 +50,19 @@ type Stat struct {
 func (g *Stat) Prepare(ctx context.Context) error {
 	// prepare the bench by listing object from the bucket
 	if g.ListExisting {
-		cl, done := g.Client()
-
-		// ensure the bucket exist
-		found, err := cl.BucketExists(ctx, g.Bucket)
+		objects, err := g.listExistingObjects(ctx, ListObjectsConfig{
+			Bucket:         g.Bucket,
+			Prefix:         g.ListPrefix,
+			ListFlat:       g.ListFlat,
+			CreateObjects:  g.CreateObjects,
+			FilterZeroSize: true,
+			HandleVersions: g.Versions > 1,
+			MaxVersions:    g.Versions,
+		})
 		if err != nil {
 			return err
 		}
-		if !found {
-			return (fmt.Errorf("bucket %s does not exist and --list-existing has been set", g.Bucket))
-		}
-
-		// list all objects
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		objectCh := cl.ListObjects(ctx, g.Bucket, minio.ListObjectsOptions{
-			WithVersions: g.Versions > 1,
-			Prefix:       g.ListPrefix,
-			Recursive:    !g.ListFlat,
-		})
-
-		versions := map[string]int{}
-
-		for object := range objectCh {
-			if object.Err != nil {
-				return object.Err
-			}
-			if object.Size == 0 {
-				continue
-			}
-			obj := generator.Object{
-				Name: object.Key,
-				Size: object.Size,
-			}
-
-			if g.Versions > 1 {
-				if object.VersionID == "" {
-					continue
-				}
-
-				if version, found := versions[object.Key]; found {
-					if version >= g.Versions {
-						continue
-					}
-				}
-				versions[object.Key]++
-				obj.VersionID = object.VersionID
-			}
-
-			g.objects = append(g.objects, obj)
-
-			// limit to ListingMaxObjects
-			if g.CreateObjects > 0 && len(g.objects) >= g.CreateObjects {
-				break
-			}
-		}
-		if len(g.objects) == 0 {
-			return (fmt.Errorf("no objects found for bucket %s", g.Bucket))
-		}
-		done()
+		g.objects = objects
 		return nil
 	}
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Extracts duplicate object listing code from delete.go, get.go, and stat.go into a shared listExistingObjects method in Common. This reduces code duplication by ~150 lines and centralizes listing behavior, making future maintenance and bug fixes easier.

The new ListObjectsConfig struct allows each benchmark type to configure listing behavior (version handling, zero-size filtering, shuffling) while sharing the core implementation.

## Motivation and Context

This increase in maintainability from refactoring applies to everyone, but specifically, If anyone wanted to carry a patch relating to prefixes (see discussion in #432), having listing logic consolidated makes that easier. 

## How to test this PR?

Basic regression testing of --list-existing behavior for the get, delete, and stat commands.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
