### PR TITLE
feat: add --concurrent-mode=fixed for connection density testing

### DIFF
--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -659,6 +659,14 @@ func checkBenchmark(ctx *cli.Context) {
 			fatalIf(errDummy(), "autoterm.pct cannot be zero or negative")
 		}
 	}
+	if mode := ctx.String("concurrent-mode"); mode != "" {
+		if mode != "fixed" {
+			fatalIf(errDummy(), "concurrent-mode %q unrecognized. Supported values: 'fixed'", mode)
+		}
+		if ctx.Float64("rps-limit") <= 0 {
+			fatalIf(errDummy(), "--concurrent-mode=fixed requires --rps-limit to be set")
+		}
+	}
 }
 
 // time format for start time.

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/minio/cli"
 	"github.com/minio/mc/pkg/probe"
@@ -281,6 +282,11 @@ var ioFlags = []cli.Flag{
 		Value: 0,
 		Usage: "Rate limit each instance to this number of requests per second (0 to disable)",
 	},
+	cli.StringFlag{
+		Name:  "concurrent-mode",
+		Value: "",
+		Usage: "Concurrency mode. 'fixed' keeps all --concurrent goroutines active throughout the run using per-goroutine sleep pacing (sleep = concurrent/rps-limit). Requires --rps-limit. Default treats --concurrent as a maximum.",
+	},
 	cli.BoolFlag{
 		Name:   "stdout",
 		Usage:  "Send operations to stdout",
@@ -337,9 +343,14 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 
 	rpsLimit := ctx.Float64("rps-limit")
 	var rpsLimiter *rate.Limiter
+	var rpsSleepDur time.Duration
 	if rpsLimit > 0 {
-		// set burst to 1 as limiter will always be called to wait for 1 token
-		rpsLimiter = rate.NewLimiter(rate.Limit(rpsLimit), 1)
+		if ctx.String("concurrent-mode") == "fixed" {
+			rpsSleepDur = time.Duration(float64(ctx.Int("concurrent")) / rpsLimit * float64(time.Second))
+		} else {
+			// set burst to 1 as limiter will always be called to wait for 1 token
+			rpsLimiter = rate.NewLimiter(rate.Limit(rpsLimit), 1)
+		}
 	}
 	// Create put options now, so ensure that trailing headers are set.
 	putOpts := putOpts(ctx)
@@ -353,6 +364,7 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 		DiscardOutput: noOps,
 		ExtraOut:      extra,
 		RpsLimiter:    rpsLimiter,
+		RpsSleepDur:   rpsSleepDur,
 		Transport:     clientTransport(ctx),
 		UpdateStatus:  statusln,
 	}

--- a/pkg/bench/benchmark.go
+++ b/pkg/bench/benchmark.go
@@ -104,6 +104,12 @@ type Common struct {
 	// ratelimiting
 	RpsLimiter *rate.Limiter
 
+	// RpsSleepDur is set when --concurrent-mode=fixed. Each goroutine sleeps
+	// this duration between operations instead of competing for a shared token
+	// bucket, keeping all --concurrent goroutines active with warm connections.
+	// Value is concurrent/rps-limit seconds, computed once at startup.
+	RpsSleepDur time.Duration
+
 	// Transport used.
 	Transport http.RoundTripper
 
@@ -261,10 +267,17 @@ func (c *Common) prepareProgress(progress float64) {
 }
 
 func (c *Common) rpsLimit(ctx context.Context) error {
+	if c.RpsSleepDur > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(c.RpsSleepDur):
+			return nil
+		}
+	}
 	if c.RpsLimiter == nil {
 		return nil
 	}
-
 	return c.RpsLimiter.Wait(ctx)
 }
 


### PR DESCRIPTION
## Problem

When `--rps-limit` is set with a high `--concurrent` value, the default token bucket (`burst=1`) collapses effective concurrency to ~1. All goroutines compete for a single token and block before ever opening a TCP connection. The configured `--concurrent` goroutines are never in-flight simultaneously.

Real-world impact: a customer running `--concurrent=2250 --rps-limit=3150` across 8 clients (18,000 goroutines configured) had only ~8 goroutines in-flight and ~252 active connections — the connection density test they intended was not being exercised at all.

## Solution

`--concurrent-mode=fixed` replaces the shared token bucket with per-goroutine sleep pacing:

```
sleep duration = concurrent / rps-limit   (seconds)
```

Each goroutine sleeps independently after each operation. All goroutines stay active throughout the run, holding warm keep-alive connections. Aggregate RPS across all goroutines converges to the `--rps-limit` target.

## Usage

```bash
warp mixed   --concurrent 2250   --rps-limit 3150   --concurrent-mode fixed   ...
```

## Changes

- `cli/flags.go` — add `--concurrent-mode` StringFlag; compute `rpsSleepDur` instead of constructing `rpsLimiter` when `mode=fixed`
- `pkg/bench/benchmark.go` — add `RpsSleepDur` field to `Common`; `rpsLimit()` checks sleep path before token bucket
- `cli/benchmark.go` — validate `--concurrent-mode` value and require `--rps-limit` when set

## Behavior

- Default behavior (token bucket) is **unchanged** — `--concurrent-mode` is opt-in
- Works in distributed mode automatically — the flag is forwarded to all clients like any other `ioFlag`
- No benchmark files (`get.go`, `put.go`, `mixed.go`, etc.) were modified — existing `rpsLimit()` call sites work for both modes unchanged

## Test Results

Lab: 4 warp clients, 4 MinIO nodes. `--concurrent=50 --rps-limit=5` × 4 clients = 200 goroutines, 10s sleep per goroutine.

| Mode | Active TCP connections |
|---|---|
| Token bucket (default) | ~40 |
| `--concurrent-mode=fixed` | ~218 |

Fixed mode held ~218 connections throughout a 90-second run. Token bucket held ~40 (~20% of configured goroutines).