### PR TITLE
Fix RPS limit

### DIFF
--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -681,6 +681,9 @@ func checkBenchmark(ctx *cli.Context) {
 			fatalIf(errDummy(), "autoterm.pct cannot be zero or negative")
 		}
 	}
+	if ctx.Int("concurrent") <= 0 {
+		fatalIf(errDummy(), "invalid concurrent value: %d", ctx.Int("concurrent"))
+	}
 }
 
 // time format for start time.

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -343,8 +343,8 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 	rpsLimit := ctx.Float64("rps-limit")
 	var rpsLimiter *rate.Limiter
 	if rpsLimit > 0 {
-		// set burst to 1 as limiter will always be called to wait for 1 token
-		rpsLimiter = rate.NewLimiter(rate.Limit(rpsLimit), 1)
+		// Allow for concurrent bursts.
+		rpsLimiter = rate.NewLimiter(rate.Limit(rpsLimit), ctx.Int("concurrent"))
 	}
 	// Create put options now, so ensure that trailing headers are set.
 	putOpts := putOpts(ctx)

--- a/cli/iceberg_catalog_read.go
+++ b/cli/iceberg_catalog_read.go
@@ -297,7 +297,7 @@ func getIcebergCommon(ctx *cli.Context) bench.Common {
 	rpsLimit := ctx.Float64("rps-limit")
 	var rpsLimiter *rate.Limiter
 	if rpsLimit > 0 {
-		rpsLimiter = rate.NewLimiter(rate.Limit(rpsLimit), 1)
+		rpsLimiter = rate.NewLimiter(rate.Limit(rpsLimit), ctx.Int("concurrent"))
 	}
 
 	return bench.Common{

--- a/pkg/bench/fanout.go
+++ b/pkg/bench/fanout.go
@@ -73,6 +73,11 @@ func (u *Fanout) Start(ctx context.Context, wait chan struct{}) error {
 					return
 				default:
 				}
+
+				if u.rpsLimit(ctx) != nil {
+					return
+				}
+
 				obj := src.Object()
 				for i := range opts.Entries {
 					opts.Entries[i] = minio.PutObjectFanOutEntry{

--- a/pkg/bench/iceberg_sustained.go
+++ b/pkg/bench/iceberg_sustained.go
@@ -409,7 +409,7 @@ func (b *Iceberg) Start(ctx context.Context, wait chan struct{}) error {
 	if b.SimulateRead {
 		readWorkers = b.ReadConcurrent
 		if b.ReadRpsLimit > 0 {
-			b.readRpsLimiter = rate.NewLimiter(rate.Limit(b.ReadRpsLimit), 1)
+			b.readRpsLimiter = rate.NewLimiter(rate.Limit(b.ReadRpsLimit), readWorkers)
 		}
 	}
 	wg.Add(b.Concurrency + readWorkers)

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -180,10 +180,6 @@ func (g *Mixed) Prepare(ctx context.Context) error {
 				default:
 				}
 
-				if g.rpsLimit(ctx) != nil {
-					return
-				}
-
 				obj := src.Object()
 				client, clDone := g.Client()
 				opts.ContentType = obj.ContentType

--- a/pkg/bench/versioned.go
+++ b/pkg/bench/versioned.go
@@ -82,10 +82,6 @@ func (g *Versioned) Prepare(ctx context.Context) error {
 				default:
 				}
 
-				if g.rpsLimit(ctx) != nil {
-					return
-				}
-
 				obj := src.Object()
 				client, clDone := g.Client()
 				opts.ContentType = obj.ContentType


### PR DESCRIPTION
RPS limit would ignore concurrency. Allow bursts up to the concurrency, so if RPS limit isn't hit it will operate as normal.

* Add RPS limit to fanout.

* Remove RPS from versioned/mixed since operations aren't part of the recorded benchmark.

Verified other RPS limits.

Replaces https://github.com/minio/warp/pull/485