### PR TITLE
adding support for different buckets on clients

### DIFF
--- a/cli/analyze.go
+++ b/cli/analyze.go
@@ -572,7 +572,8 @@ func printRequestAnalysis(_ *cli.Context, ops aggregate.Operation, details bool)
 			", Fastest: ", time.Duration(reqs.FastestMillis)*time.Millisecond,
 			", Slowest: ", time.Duration(reqs.SlowestMillis)*time.Millisecond,
 			", StdDev: ", time.Duration(reqs.StdDev)*time.Millisecond,
-			"\n")
+			"\n",
+		)
 
 		if reqs.FirstByte != nil {
 			console.Println(" * TTFB:", reqs.FirstByte)
@@ -588,7 +589,8 @@ func printRequestAnalysis(_ *cli.Context, ops aggregate.Operation, details bool)
 				", Fastest: ", time.Duration(reqs.FastestMillis)*time.Millisecond,
 				", Slowest: ", time.Duration(reqs.SlowestMillis)*time.Millisecond,
 				", StdDev: ", time.Duration(reqs.StdDev)*time.Millisecond,
-				"\n")
+				"\n",
+			)
 			if reqs.FirstByte != nil {
 				console.Print(" * First Access TTFB: ", reqs.FirstByte, "\n")
 			}
@@ -603,7 +605,8 @@ func printRequestAnalysis(_ *cli.Context, ops aggregate.Operation, details bool)
 				", Fastest: ", time.Duration(reqs.FastestMillis)*time.Millisecond,
 				", Slowest: ", time.Duration(reqs.SlowestMillis)*time.Millisecond,
 				", StdDev: ", time.Duration(reqs.StdDev)*time.Millisecond,
-				"\n")
+				"\n",
+			)
 			if reqs.FirstByte != nil {
 				console.Print(" * Last Access TTFB: ", reqs.FirstByte, "\n")
 			}

--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -116,6 +116,11 @@ func runBench(ctx *cli.Context, b bench.Benchmark) error {
 	if ab != nil {
 		c.ClientIdx = ab.clientIdx
 		c.TotalClients = ab.totalClients
+		if ctx.Bool("bucket-per-client") {
+			// Give this client its own bucket so distributed clients do
+			// not share/clobber each other's data.
+			c.Bucket = fmt.Sprintf("%s-%d", c.Bucket, c.ClientIdx)
+		}
 		return runClientBenchmark(ctx, b, ab)
 	}
 	if done, err := runServerBenchmark(ctx, b); done || err != nil {

--- a/cli/benchserver.go
+++ b/cli/benchserver.go
@@ -353,7 +353,12 @@ func runServerBenchmark(ctx *cli.Context, b bench.Benchmark) (bool, error) {
 	if !ctx.Bool("keep-data") && !ctx.Bool("noclear") {
 		ui.SetPhase("Cleanup")
 		monitor.InfoLn("Starting cleanup...")
-		b.Cleanup(context.Background())
+		// With per-client buckets there is no shared base bucket for the
+		// server to clean; each client clears its own bucket in the cleanup
+		// stage below.
+		if !ctx.Bool("bucket-per-client") {
+			b.Cleanup(context.Background())
+		}
 
 		err = conns.startStageAll(stageCleanup, time.Now(), false)
 		if err != nil {

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -210,6 +210,10 @@ var ioFlags = []cli.Flag{
 		Value: appName + "-benchmark-bucket",
 		Usage: "Bucket to use for benchmark data. ALL DATA WILL BE DELETED IN BUCKET!",
 	},
+	cli.BoolFlag{
+		Name:  "bucket-per-client",
+		Usage: "In distributed mode, give each warp client its own bucket by appending the client index to --bucket (e.g. bucket-0, bucket-1). Each client creates, uses and clears its own bucket.",
+	},
 	cli.StringFlag{
 		Name:  "host-select",
 		Value: string(hostSelectTypeWeighed),

--- a/pkg/aggregate/requests.go
+++ b/pkg/aggregate/requests.go
@@ -238,7 +238,8 @@ func (s RequestSizeRange) String() string {
 	if s.MergedEntries <= 0 || s.Requests == 0 {
 		return ""
 	}
-	return fmt.Sprint("Average: ", bench.Throughput(s.BpsAverage),
+	return fmt.Sprint(
+		"Average: ", bench.Throughput(s.BpsAverage),
 		", 50%: ", bench.Throughput(s.BpsMedian),
 		", 90%: ", bench.Throughput(s.Bps90),
 		", 99%: ", bench.Throughput(s.Bps99),
@@ -252,7 +253,8 @@ func (s RequestSizeRange) StringByN() string {
 		return ""
 	}
 	mul := 1 / float64(s.MergedEntries)
-	return fmt.Sprint("Avg: ", bench.Throughput(s.BpsAverage*mul),
+	return fmt.Sprint(
+		"Avg: ", bench.Throughput(s.BpsAverage*mul),
 		", 50%: ", bench.Throughput(s.BpsMedian*mul),
 		", 90%: ", bench.Throughput(s.Bps90*mul),
 		", 99%: ", bench.Throughput(s.Bps99*mul),

--- a/pkg/bench/compare.go
+++ b/pkg/bench/compare.go
@@ -95,7 +95,8 @@ func (c *CmpReqs) String() string {
 	if c == nil {
 		return ""
 	}
-	return fmt.Sprintf("Avg: %s%v (%s%.f%%), P50: %s%v (%s%.f%%), P99: %s%v (%s%.f%%), Best: %s%v (%s%.f%%), Worst: %s%v (%s%.f%%) StdDev: %s%v (%s%.f%%)",
+	return fmt.Sprintf(
+		"Avg: %s%v (%s%.f%%), P50: %s%v (%s%.f%%), P99: %s%v (%s%.f%%), Best: %s%v (%s%.f%%), Worst: %s%v (%s%.f%%) StdDev: %s%v (%s%.f%%)",
 		plusPositiveD(c.Average),
 		c.Average.Round(time.Millisecond/20),
 		plusPositiveD(c.Average),
@@ -145,12 +146,14 @@ func (c CmpSegment) String() string {
 	mibA, _, objsA := c.After.SpeedPerSec()
 
 	if c.ThroughputPerSec != 0 {
-		speed = fmt.Sprintf("%s%.02f%% (%s%.1f MiB/s) throughput, ",
+		speed = fmt.Sprintf(
+			"%s%.02f%% (%s%.1f MiB/s) throughput, ",
 			plusPositiveF(c.ThroughputPerSec), c.ThroughputPerSec,
 			plusPositiveF(c.ThroughputPerSec), mibA-mibB,
 		)
 	}
-	return fmt.Sprintf("%s%s%.02f%% (%s%.1f) obj/s",
+	return fmt.Sprintf(
+		"%s%s%.02f%% (%s%.1f) obj/s",
 		speed, plusPositiveF(c.ObjPerSec), c.ObjPerSec,
 		plusPositiveF(objsA-objsB), objsA-objsB,
 	)
@@ -198,7 +201,8 @@ func (t *TTFBCmp) String() string {
 	if t == nil {
 		return ""
 	}
-	return fmt.Sprintf("Avg: %s%v (%s%.f%%), P50: %s%v (%s%.f%%), P99: %s%v (%s%.f%%), Best: %s%v (%s%.f%%), Worst: %s%v (%s%.f%%) StdDev: %s%v (%s%.f%%)",
+	return fmt.Sprintf(
+		"Avg: %s%v (%s%.f%%), P50: %s%v (%s%.f%%), P99: %s%v (%s%.f%%), Best: %s%v (%s%.f%%), Worst: %s%v (%s%.f%%) StdDev: %s%v (%s%.f%%)",
 		plusPositiveD(t.Average),
 		t.Average.Round(time.Millisecond/20),
 		plusPositiveD(t.Average),

--- a/pkg/bench/iceberg_sustained.go
+++ b/pkg/bench/iceberg_sustained.go
@@ -255,7 +255,8 @@ tableLoop:
 			var loadedTbl *table.Table
 			var err error
 			if b.ExternalCatalog != warpiceberg.ExternalCatalogNone {
-				loadedTbl, err = cat.CreateTable(errCtx, ident, schema,
+				loadedTbl, err = cat.CreateTable(
+					errCtx, ident, schema,
 					catalogpkg.WithLocation(tbl.Location),
 				)
 			} else {

--- a/pkg/iceberg/catalog.go
+++ b/pkg/iceberg/catalog.go
@@ -216,7 +216,8 @@ func LoadOrCreateTable(ctx context.Context, cat catalog.Catalog, namespace, tabl
 	}
 
 	// Table doesn't exist, create it
-	tbl, err = cat.CreateTable(ctx, ident, schema,
+	tbl, err = cat.CreateTable(
+		ctx, ident, schema,
 		catalog.WithProperties(iceberg.Properties{
 			"format-version": "2",
 		}),
@@ -251,7 +252,8 @@ func LoadOrCreateTable(ctx context.Context, cat catalog.Catalog, namespace, tabl
 	_ = cat.DropTable(ctx, ident)
 	time.Sleep(500 * time.Millisecond)
 
-	tbl, err = cat.CreateTable(ctx, ident, schema,
+	tbl, err = cat.CreateTable(
+		ctx, ident, schema,
 		catalog.WithProperties(iceberg.Properties{
 			"format-version": "2",
 		}),

--- a/pkg/iceberg/dataset.go
+++ b/pkg/iceberg/dataset.go
@@ -116,7 +116,8 @@ tableLoop:
 			defer func() { <-sem }()
 
 			ident := toTableIdentifier(tbl.Namespace, tbl.Name)
-			_, err := d.getCatalog().CreateTable(errCtx, ident, schema,
+			_, err := d.getCatalog().CreateTable(
+				errCtx, ident, schema,
 				catalog.WithLocation(tbl.Location),
 				catalog.WithProperties(props),
 			)
@@ -181,7 +182,8 @@ viewLoop:
 
 			ident := toTableIdentifier(vw.Namespace, vw.Name)
 			version := rest.BuildIcebergViewVersion(vw.Namespace, vw.Name)
-			_, err := d.getCatalog().CreateView(errCtx, ident, version, schema,
+			_, err := d.getCatalog().CreateView(
+				errCtx, ident, version, schema,
 				catalog.WithViewLocation(vw.Location),
 				catalog.WithViewProperties(props),
 			)

--- a/pkg/iceberg/schema.go
+++ b/pkg/iceberg/schema.go
@@ -24,7 +24,8 @@ import (
 // BenchmarkDataSchema returns the Iceberg schema for benchmark data files.
 // This matches the Arrow schema in BenchmarkSchema() in parquet.go.
 func BenchmarkDataSchema() *iceberg.Schema {
-	return iceberg.NewSchema(0,
+	return iceberg.NewSchema(
+		0,
 		iceberg.NestedField{
 			ID:       1,
 			Name:     "id",

--- a/pkg/iceberg/tpcds.go
+++ b/pkg/iceberg/tpcds.go
@@ -236,7 +236,8 @@ func GetCachedTPCDSFiles(cfg TPCDSConfig) ([]string, error) {
 
 // StoreSalesSchema returns the Iceberg schema for TPC-DS store_sales table.
 func StoreSalesSchema() *iceberg.Schema {
-	return iceberg.NewSchema(0,
+	return iceberg.NewSchema(
+		0,
 		iceberg.NestedField{ID: 1, Name: "ss_sold_date_sk", Type: iceberg.PrimitiveTypes.Int64, Required: false},
 		iceberg.NestedField{ID: 2, Name: "ss_sold_time_sk", Type: iceberg.PrimitiveTypes.Int64, Required: false},
 		iceberg.NestedField{ID: 3, Name: "ss_item_sk", Type: iceberg.PrimitiveTypes.Int64, Required: false},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--bucket-per-client` option for distributed benchmarks so each client can use its own bucket.

* **Bug Fixes**
  * Improved benchmark cleanup behavior to avoid shared-bucket cleanup when client-specific buckets are enabled.
  * Updated bucket naming in distributed runs to prevent clients from writing to the same bucket.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->