### PR TITLE
[Duplicate] Add --dns-cache-ttl to avoid DNS storm at high concurrency

### DIFF
--- a/cli/client_ktls.go
+++ b/cli/client_ktls.go
@@ -18,6 +18,8 @@
 package cli
 
 import (
+	"context"
+	"net"
 	stdHttp "net/http"
 	"os"
 	"time"
@@ -53,17 +55,27 @@ func clientTransportKTLS(ctx *cli.Context, localIP string) stdHttp.RoundTripper 
 	}
 
 	netD := makeDialer(localIP)
+	cache := getDNSCache(ctx)
 
 	// If we don't enable http/2, then using a custom DialTLSConext is the best choice.
 	// It can improve performance by not using a compatibility layer.
 	if !ctx.Bool("http2") {
 		dialer := &tls.Dialer{NetDialer: netD, Config: tlsConfig}
-		return newClientTransport(ctx, withDialTLSContext(dialer.DialContext))
+		dialTLS := dialer.DialContext
+		if cache.enabled() {
+			dialTLS = cachedDialTLS(cache, netD, tlsConfig)
+		}
+		return newClientTransport(ctx, withDialTLSContext(dialTLS))
+	}
+
+	h2Dial := netD.DialContext
+	if cache.enabled() {
+		h2Dial = cache.dialContext(netD.DialContext)
 	}
 
 	tr := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           netD.DialContext,
+		DialContext:           h2Dial,
 		MaxIdleConnsPerHost:   ctx.Int("concurrent"),
 		WriteBufferSize:       ctx.Int("sndbuf"), // Configure beyond 4KiB default buffer size.
 		ReadBufferSize:        ctx.Int("rcvbuf"), // Configure beyond 4KiB default buffer size.
@@ -88,4 +100,29 @@ func clientTransportKTLS(ctx *cli.Context, localIP string) stdHttp.RoundTripper 
 	}
 
 	return &http.CompatableTransport{Transport: tr}
+}
+
+// cachedDialTLS returns a DialTLSContext that resolves the FQDN through the
+// shared DNS cache for the TCP connection while pinning the TLS ServerName to
+// the original FQDN. Unlike the plain DialContext paths (where net/http derives
+// SNI from the request URL), a tls.Dialer derives SNI from the dial address, so
+// substituting an IP would break SNI/certificate validation unless ServerName
+// is set explicitly here.
+func cachedDialTLS(cache *dnsCache, netD *net.Dialer, cfg *tls.Config) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialAddr := addr
+		c := cfg.Clone()
+		if host, port, err := net.SplitHostPort(addr); err == nil && host != "" && net.ParseIP(host) == nil {
+			if c.ServerName == "" {
+				c.ServerName = host
+			}
+			ip, lerr := cache.lookup(ctx, host)
+			if lerr != nil {
+				return nil, lerr
+			}
+			dialAddr = net.JoinHostPort(ip, port)
+		}
+		d := &tls.Dialer{NetDialer: netD, Config: c}
+		return d.DialContext(ctx, network, dialAddr)
+	}
 }

--- a/cli/client_transport.go
+++ b/cli/client_transport.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/minio/cli"
@@ -30,6 +31,24 @@ import (
 var netDialer = &net.Dialer{
 	Timeout:   10 * time.Second,
 	KeepAlive: 10 * time.Second,
+}
+
+// sharedDNSCache is the process-wide DNS cache, initialized once from the
+// --dns-cache-ttl flag. It is shared by every transport/client so a single
+// FQDN is resolved at most once per TTL regardless of concurrency or the
+// number of clients created by host selection.
+var (
+	dnsCacheOnce   sync.Once
+	sharedDNSCache *dnsCache
+)
+
+// getDNSCache returns the shared DNS cache, initializing it on first use from
+// the --dns-cache-ttl flag value.
+func getDNSCache(ctx *cli.Context) *dnsCache {
+	dnsCacheOnce.Do(func() {
+		sharedDNSCache = newDNSCache(ctx.Duration("dns-cache-ttl"))
+	})
+	return sharedDNSCache
 }
 
 // makeDialer returns a Dialer optionally bound to localIP.
@@ -95,6 +114,14 @@ func newClientTransport(ctx *cli.Context, options ...transportOption) http.Round
 
 	for _, option := range options {
 		option(tr)
+	}
+
+	// Route the TCP dial through the shared DNS cache (no-op when the TTL is
+	// 0 or the host is a literal IP). Only DialContext is wrapped here; the
+	// kTLS non-HTTP/2 path installs a cache-aware DialTLSContext itself, so we
+	// must not clobber it.
+	if cache := getDNSCache(ctx); cache.enabled() && tr.DialContext != nil && tr.DialTLSContext == nil {
+		tr.DialContext = cache.dialContext(tr.DialContext)
 	}
 
 	return tr

--- a/cli/dnscache.go
+++ b/cli/dnscache.go
@@ -1,0 +1,182 @@
+/*
+ * Warp (C) 2019-2025 MinIO, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/minio/pkg/v3/console"
+)
+
+// dnsCache is a process-wide, TTL-bounded DNS cache shared by all transports.
+//
+// Go's pure resolver (forced when the binary is built with CGO_ENABLED=0, as
+// warp's release binaries are) performs a fresh lookup on every dial and does
+// no in-process caching. Under high --concurrent that produces a burst of DNS
+// queries ("DNS storm") for a single FQDN host. This cache resolves a hostname
+// at most once per TTL regardless of concurrency, while leaving the FQDN itself
+// untouched so the client keeps using it for TLS SNI, certificate validation
+// and the Host header.
+type dnsCache struct {
+	ttl time.Duration
+
+	mu      sync.Mutex
+	entries map[string]*dnsEntry
+}
+
+type dnsEntry struct {
+	ips     []string  // resolved IPs (host part only, no port)
+	expires time.Time // when the entry must be re-resolved
+	next    uint64    // round-robin cursor across ips
+	// resolving guards a single in-flight re-resolution so that only one
+	// dial re-resolves on expiry while the others keep using the stale set.
+	resolving bool
+	logged    bool // whether the initial resolution was logged
+}
+
+// newDNSCache returns a cache with the given TTL. A ttl <= 0 disables caching
+// (the returned cache passes every dial straight through to the OS resolver).
+func newDNSCache(ttl time.Duration) *dnsCache {
+	return &dnsCache{
+		ttl:     ttl,
+		entries: make(map[string]*dnsEntry),
+	}
+}
+
+// enabled reports whether caching is active.
+func (c *dnsCache) enabled() bool {
+	return c != nil && c.ttl > 0
+}
+
+// dialContext returns a DialContext that resolves the host part of addr through
+// the cache (when enabled and the host is not a literal IP) and dials the
+// selected cached IP. base performs the actual TCP dial and must accept a
+// "host:port" address.
+func (c *dnsCache) dialContext(base func(ctx context.Context, network, addr string) (net.Conn, error)) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if !c.enabled() {
+			return base(ctx, network, addr)
+		}
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			// No port; treat the whole thing as the host.
+			host, port = addr, ""
+		}
+		// Literal IPs need no resolution.
+		if host == "" || net.ParseIP(host) != nil {
+			return base(ctx, network, addr)
+		}
+
+		ip, err := c.lookup(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		dialAddr := ip
+		if port != "" {
+			dialAddr = net.JoinHostPort(ip, port)
+		}
+		return base(ctx, network, dialAddr)
+	}
+}
+
+// lookup returns one cached IP for host, resolving (once per TTL) as needed.
+func (c *dnsCache) lookup(ctx context.Context, host string) (string, error) {
+	c.mu.Lock()
+	e := c.entries[host]
+	now := time.Now()
+
+	// Fresh entry: hand out the next IP round-robin.
+	if e != nil && len(e.ips) > 0 && now.Before(e.expires) {
+		ip := e.pick()
+		c.mu.Unlock()
+		return ip, nil
+	}
+
+	// Expired (or new) but another dial is already re-resolving: serve the
+	// stale set if we have one, otherwise fall through to resolve inline.
+	if e != nil && len(e.ips) > 0 && e.resolving {
+		ip := e.pick()
+		c.mu.Unlock()
+		return ip, nil
+	}
+
+	// We are the resolver for this host.
+	if e == nil {
+		e = &dnsEntry{}
+		c.entries[host] = e
+	}
+	e.resolving = true
+	stale := append([]string(nil), e.ips...)
+	logged := e.logged
+	c.mu.Unlock()
+
+	ips, err := resolveHostIPs(ctx, host)
+
+	c.mu.Lock()
+	e.resolving = false
+	if err != nil || len(ips) == 0 {
+		// Keep serving the last successful set; never stop the benchmark
+		// on a transient DNS failure.
+		if len(stale) > 0 {
+			ip := e.pick()
+			c.mu.Unlock()
+			return ip, nil
+		}
+		c.mu.Unlock()
+		if err == nil {
+			err = &net.DNSError{Err: "no addresses found", Name: host}
+		}
+		return "", err
+	}
+	e.ips = ips
+	e.expires = time.Now().Add(c.ttl)
+	if !logged {
+		e.logged = true
+		console.Infoln("DNS cache: resolved", host, "->", strings.Join(ips, ", "), "(ttl", c.ttl.String()+")")
+	}
+	ip := e.pick()
+	c.mu.Unlock()
+	return ip, nil
+}
+
+// pick returns the next IP round-robin. Caller must hold c.mu.
+func (e *dnsEntry) pick() string {
+	if len(e.ips) == 1 {
+		return e.ips[0]
+	}
+	n := atomic.AddUint64(&e.next, 1)
+	return e.ips[int(n-1)%len(e.ips)]
+}
+
+// resolveHostIPs resolves host to its IP addresses (host part only).
+func resolveHostIPs(ctx context.Context, host string) ([]string, error) {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		ips = append(ips, a.IP.String())
+	}
+	return ips, nil
+}

--- a/cli/dnscache_test.go
+++ b/cli/dnscache_test.go
@@ -1,0 +1,132 @@
+/*
+ * Warp (C) 2019-2025 MinIO, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDNSCacheDisabled(t *testing.T) {
+	c := newDNSCache(0)
+	if c.enabled() {
+		t.Fatal("cache with ttl 0 must be disabled")
+	}
+	var nilCache *dnsCache
+	if nilCache.enabled() {
+		t.Fatal("nil cache must be disabled")
+	}
+
+	// A disabled cache must dial through untouched.
+	var gotAddr string
+	base := func(_ context.Context, _, addr string) (net.Conn, error) {
+		gotAddr = addr
+		return nil, nil
+	}
+	_, _ = c.dialContext(base)(context.Background(), "tcp", "example.com:9000")
+	if gotAddr != "example.com:9000" {
+		t.Fatalf("disabled cache altered dial address: got %q", gotAddr)
+	}
+}
+
+func TestDNSCacheLiteralIPPassthrough(t *testing.T) {
+	c := newDNSCache(time.Minute)
+	var gotAddr string
+	base := func(_ context.Context, _, addr string) (net.Conn, error) {
+		gotAddr = addr
+		return nil, nil
+	}
+	// Literal IPs must not be resolved/cached.
+	_, _ = c.dialContext(base)(context.Background(), "tcp", "10.0.0.1:9000")
+	if gotAddr != "10.0.0.1:9000" {
+		t.Fatalf("literal IP was altered: got %q", gotAddr)
+	}
+	if len(c.entries) != 0 {
+		t.Fatalf("literal IP should not create a cache entry, got %d", len(c.entries))
+	}
+}
+
+func TestDNSCacheResolvesOncePerTTL(t *testing.T) {
+	c := newDNSCache(time.Hour)
+	// Prime with a fresh entry directly to avoid depending on real DNS.
+	c.mu.Lock()
+	c.entries["host.example"] = &dnsEntry{
+		ips:     []string{"192.0.2.1", "192.0.2.2"},
+		expires: time.Now().Add(time.Hour),
+	}
+	c.mu.Unlock()
+
+	// Many lookups within TTL must not re-resolve and must round-robin.
+	seen := map[string]int{}
+	for i := 0; i < 100; i++ {
+		ip, err := c.lookup(context.Background(), "host.example")
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen[ip]++
+	}
+	if seen["192.0.2.1"] == 0 || seen["192.0.2.2"] == 0 {
+		t.Fatalf("expected round-robin across both IPs, got %v", seen)
+	}
+}
+
+func TestDNSCacheKeepsStaleOnFailure(t *testing.T) {
+	c := newDNSCache(time.Millisecond)
+	// An already-expired entry with a stale set for a name that will fail to
+	// resolve (reserved .invalid TLD). The stale value must still be served
+	// rather than propagating the DNS error.
+	c.mu.Lock()
+	c.entries["nonexistent.invalid"] = &dnsEntry{
+		ips:     []string{"203.0.113.5"},
+		expires: time.Now().Add(-time.Hour),
+	}
+	c.mu.Unlock()
+
+	ip, err := c.lookup(context.Background(), "nonexistent.invalid")
+	if err != nil {
+		t.Fatalf("expected stale value to be served, got error: %v", err)
+	}
+	if ip != "203.0.113.5" {
+		t.Fatalf("expected stale IP 203.0.113.5, got %q", ip)
+	}
+}
+
+func TestDNSCacheConcurrentSingleFlight(t *testing.T) {
+	c := newDNSCache(time.Hour)
+	c.mu.Lock()
+	c.entries["cc.example"] = &dnsEntry{
+		ips:     []string{"198.51.100.7"},
+		expires: time.Now().Add(time.Hour),
+	}
+	c.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.lookup(context.Background(), "cc.example"); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -220,6 +220,10 @@ var ioFlags = []cli.Flag{
 		Usage:  "Resolve the host(s) ip(s) (including multiple A/AAAA records). This can break SSL certificates, use --insecure if so",
 		Hidden: true,
 	},
+	cli.DurationFlag{
+		Name:  "dns-cache-ttl",
+		Usage: "Cache DNS resolution of the host FQDN for this duration to avoid a DNS query per connection at high concurrency. 0 disables caching. The FQDN is kept for TLS SNI and the Host header",
+	},
 	cli.IntFlag{
 		Name:  "concurrent",
 		Value: 20,


### PR DESCRIPTION
With CGO_ENABLED=0 (warp's release build), Go uses the pure resolver which does no in-process DNS caching and performs a fresh lookup on every dial. At high --concurrent against an FQDN host this produces a burst of DNS queries per connection ("DNS storm").

Add an opt-in --dns-cache-ttl flag backed by a process-wide TTL cache: the host FQDN is resolved at most once per TTL regardless of concurrency or the number of clients created by host selection. The FQDN is kept for TLS SNI, certificate validation and the Host header; only the TCP dial address is substituted with a cached IP.

Details:
- Lazy re-resolution with single-flight on TTL expiry; on resolution failure the last successful set is kept so the benchmark is not interrupted.
- Multiple A/AAAA records are cached and handed out round-robin per dial.
- Literal IP hosts are a no-op; ttl 0 (default) disables caching and preserves the previous behavior exactly.
- Applied to all transports (default / TLS / kTLS-h2 via DialContext, kTLS-non-h2 via a DialTLSContext that pins ServerName=FQDN).
- DurationFlag propagates automatically to distributed clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--dns-cache-ttl` CLI option to control DNS caching duration.
  * Introduced shared DNS caching for outbound connections to reduce repeated lookups under high concurrency.
  * Improved TLS connection handling so cached IP dialing still preserves the original hostname for secure connections.

* **Bug Fixes**
  * Avoids unnecessary DNS resolution for literal IP addresses.
  * Preserves previously resolved addresses when a refresh fails, helping connections stay stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->