### PR TITLE
build: bump minio-go to pick up RDMA GET Stat() fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/minio/madmin-go/v4 v4.6.7
 	github.com/minio/mc v0.0.0-20251106162529-77f82e18b540
 	github.com/minio/md5-simd v1.1.2
-	github.com/minio/minio-go/v7 v7.2.0
+	github.com/minio/minio-go/v7 v7.2.2-0.20260720013402-ab51b38e91a0
 	github.com/minio/pkg/v3 v3.7.0
 	github.com/minio/websocket v1.6.0
 	github.com/muesli/termenv v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -736,8 +736,8 @@ github.com/minio/mc v0.0.0-20251106162529-77f82e18b540 h1:OAeamQLGQyf7sT/JEocLpA
 github.com/minio/mc v0.0.0-20251106162529-77f82e18b540/go.mod h1:bqx15FhQpl5JfYU3yRM4iz2z2K6DiVSaPbj9P7trZZA=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
-github.com/minio/minio-go/v7 v7.2.0 h1:RCJM0R1XOsRs+A3x3UCaf3ZYbByDaLjFeAi+YCQEPhs=
-github.com/minio/minio-go/v7 v7.2.0/go.mod h1:EU9hENAStx/xXduNdrGO5e4X5vk19NtgB+RIPjZO8o0=
+github.com/minio/minio-go/v7 v7.2.2-0.20260720013402-ab51b38e91a0 h1:W00hV244HK4cG5EZA9dvQF77hrEoBBV5rfOqGXC1eGY=
+github.com/minio/minio-go/v7 v7.2.2-0.20260720013402-ab51b38e91a0/go.mod h1:EU9hENAStx/xXduNdrGO5e4X5vk19NtgB+RIPjZO8o0=
 github.com/minio/mux v1.9.0 h1:dWafQFyEfGhJvK6AwLOt83bIG5bxKxKJnKMCi0XAaoA=
 github.com/minio/mux v1.9.0/go.mod h1:1pAare17ZRL5GpmNL+9YmqHoWnLmMZF9C/ioUCfy0BQ=
 github.com/minio/pkg/v3 v3.7.0 h1:0aL3kyWUTwqKXMMq5SQG89UU6u4+Ov2kAdtRS9I8WSQ=


### PR DESCRIPTION
Updates `github.com/minio/minio-go/v7` to include [minio/minio-go#2263](https://github.com/minio/minio-go/pull/2263).

## Problem

`warp get --rdma` reported `unexpected download size. want:<N>, got:0` on **every** RDMA GET. Root cause is in minio-go: the RDMA GET fast path builds the returned `Object` with `isClosed: true` (the payload is delivered out-of-band over RDMA), and `Object.Stat()` short-circuited on `o.isClosed` and returned an empty `ObjectInfo{}` (Size 0) before reaching the cached `objectInfo`. warp reads `o.Stat().Size`, so it always saw 0.

## Fix

minio-go#2263 makes `Stat()` return the cached `objectInfo` when set, before the `isClosed` check. This PR just vendors that release.

## Validation

Rebuilt warp `-tags=rdma` against the bumped module and ran `warp get --rdma=cpu` (256 MiB, 8-node AIStor cluster): `unexpected download size` errors went from 100% of RDMA GETs to **0** at concurrency 4 and 32; GET 25.4 GiB/s, PUT 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the S3-compatible storage integration to a newer version, bringing in the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->