### PR TITLE
build: publish the RDMA build as warp.rdma

### DIFF
--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -68,7 +68,7 @@ jobs:
         ../vcpkg/vcpkg install
         cmake . -B ./build \
           -DCMAKE_BUILD_TYPE=Release \
-          -DBUILD_SHARED_LIBS=ON \
+          -DBUILD_SHARED_LIBS=OFF \
           -DCMAKE_INSTALL_PREFIX=/usr/local \
           -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
           -DMINIO_CPP_ENABLE_RDMA:BOOL=ON
@@ -76,6 +76,8 @@ jobs:
         sudo cmake --install ./build
         cuobj_arch=$([ "${{ matrix.config.arch }}" = "amd64" ] && echo x86_64 || echo aarch64)
         sudo cp -P vendor/cuobj/lib/${cuobj_arch}/* /usr/local/lib/
+        # libminiocpp is static; its vcpkg archives must sit beside it to link.
+        sudo cp -P vcpkg_installed/*/lib/*.a /usr/local/lib/
         sudo ldconfig
 
     - name: Set up Go

--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -90,6 +90,10 @@ jobs:
       env:
         CGO_ENABLED: "1"
       run: |
+        # libminiocpp is static, so minio-go's own -lminiocpp no longer drags in
+        # the C++ runtime or the vcpkg archives; name them from the one list the
+        # build script and goreleaser config also use.
+        export CGO_LDFLAGS="-L/usr/local/lib $(cat scripts/rdma-cgo-libs.txt)"
         go build -tags=rdma -o /tmp/warp .
         go vet -tags=rdma ./...
         go test -race -tags=rdma ./...

--- a/.github/workflows/qreleaser-test.yml
+++ b/.github/workflows/qreleaser-test.yml
@@ -71,13 +71,15 @@ jobs:
           ../vcpkg/vcpkg install
           cmake . -B ./build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_SHARED_LIBS=OFF \
             -DCMAKE_INSTALL_PREFIX=/usr/local \
             -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
             -DMINIO_CPP_ENABLE_RDMA:BOOL=ON
           cmake --build ./build --config Release -j 4
           sudo cmake --install ./build
           sudo cp -P vendor/cuobj/lib/x86_64/* /usr/local/lib/
+          # libminiocpp is static; its vcpkg archives must sit beside it to link.
+          sudo cp -P vcpkg_installed/*/lib/*.a /usr/local/lib/
           sudo ldconfig
           # The libraries are installed system-wide now, and the workspace is
           # what qreleaser releases from, so leave no extra trees behind in it.

--- a/.github/workflows/qreleaser-test.yml
+++ b/.github/workflows/qreleaser-test.yml
@@ -142,20 +142,21 @@ jobs:
         run: |
           find ${{ github.workspace }}/warp-release -type f
           "${ARCH_DIR}/warp" --version
-          # The warp-rdma variant must land beside the stock binary rather than
+          # The RDMA flavor must land beside the stock binary rather than
           # replacing it, and must actually run.
-          "${ARCH_DIR}/warp-rdma" --version
+          "${ARCH_DIR}/warp.rdma" --version
           # It is the RDMA build, so it accepts --rdma=cpu where the stock
-          # binary refuses it. Guards against the variant being a copy of the
-          # stock binary under a different name.
+          # binary refuses it. Both are named warp inside their dist directories,
+          # so without this the flavor could silently be a copy of the stock
+          # binary and nothing would notice.
           if "${ARCH_DIR}/warp" put --rdma=cpu --host 127.0.0.1:9000 >/dev/null 2>&1; then
             echo "stock warp unexpectedly accepted --rdma=cpu" >&2
             exit 1
           fi
-          "${ARCH_DIR}/warp-rdma" put --rdma=cpu --host 127.0.0.1:9000 >/tmp/rdma.log 2>&1 || true
+          "${ARCH_DIR}/warp.rdma" put --rdma=cpu --host 127.0.0.1:9000 >/tmp/rdma.log 2>&1 || true
           cat /tmp/rdma.log
           if grep -q "requires the RDMA build" /tmp/rdma.log; then
-            echo "warp-rdma is not an RDMA build" >&2
+            echo "warp.rdma is not an RDMA build" >&2
             exit 1
           fi
 

--- a/.github/workflows/qreleaser-test.yml
+++ b/.github/workflows/qreleaser-test.yml
@@ -149,16 +149,23 @@ jobs:
           # binary refuses it. Both are named warp inside their dist directories,
           # so without this the flavor could silently be a copy of the stock
           # binary and nothing would notice.
-          if "${ARCH_DIR}/warp" put --rdma=cpu --host 127.0.0.1:9000 >/dev/null 2>&1; then
+          if "${ARCH_DIR}/warp" put --rdma=cpu --host 127.0.0.1:9000 >/tmp/stock.log 2>&1; then
             echo "stock warp unexpectedly accepted --rdma=cpu" >&2
             exit 1
           fi
+          cat /tmp/stock.log
+          grep -q "requires the RDMA build of warp" /tmp/stock.log
+
+          # Require a specific outcome from the flavor, not merely the absence
+          # of the refusal above: it has to get past the RDMA gate and fail at
+          # the network instead, so a crash or an unrelated error cannot pass.
           "${ARCH_DIR}/warp.rdma" put --rdma=cpu --host 127.0.0.1:9000 >/tmp/rdma.log 2>&1 || true
           cat /tmp/rdma.log
           if grep -q "requires the RDMA build" /tmp/rdma.log; then
             echo "warp.rdma is not an RDMA build" >&2
             exit 1
           fi
+          grep -q "Error preparing server" /tmp/rdma.log
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/qreleaser-test.yml
+++ b/.github/workflows/qreleaser-test.yml
@@ -35,6 +35,54 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      # The release builds the warp-rdma variant, which links libminiocpp
+      # through cgo, so the runner needs the same RDMA prerequisites as a real
+      # release host. Without them the pipeline fails on miniocpp/c_api.h.
+      - name: Checkout minio-cpp
+        uses: actions/checkout@v4
+        with:
+          repository: minio/minio-cpp
+          path: "minio-cpp"
+          persist-credentials: false
+
+      # Pinned: vcpkg's port scripts track the newest CMake, and a floating
+      # checkout breaks against whatever CMake the runner image ships.
+      - name: Checkout vcpkg
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/vcpkg
+          ref: "2026.07.29"
+          path: "vcpkg"
+          persist-credentials: false
+
+      - name: Install RDMA dependencies
+        run: |
+          sudo apt-get -qy update
+          sudo apt-get -qy install libibverbs-dev librdmacm-dev libnuma-dev
+
+      - name: Set up CMake
+        uses: lukka/get-cmake@v4.4.2
+
+      - name: Build and install libminiocpp.so with RDMA
+        shell: bash
+        run: |
+          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          cd minio-cpp
+          ../vcpkg/vcpkg install
+          cmake . -B ./build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DMINIO_CPP_ENABLE_RDMA:BOOL=ON
+          cmake --build ./build --config Release -j 4
+          sudo cmake --install ./build
+          sudo cp -P vendor/cuobj/lib/x86_64/* /usr/local/lib/
+          sudo ldconfig
+          # The libraries are installed system-wide now, and the workspace is
+          # what qreleaser releases from, so leave no extra trees behind in it.
+          cd "${GITHUB_WORKSPACE}" && rm -rf minio-cpp vcpkg
+
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
@@ -89,9 +137,27 @@ jobs:
           qreleaser main ${{ github.repository }} ${{ steps.release-type.outputs.type }}
 
       - name: Verify Release Artifacts
+        env:
+          ARCH_DIR: ${{ github.workspace }}/warp-release/${{ steps.release-type.outputs.type_dir }}/linux-amd64
         run: |
           find ${{ github.workspace }}/warp-release -type f
-          ${{ github.workspace }}/warp-release/${{ steps.release-type.outputs.type_dir }}/linux-amd64/warp --version
+          "${ARCH_DIR}/warp" --version
+          # The warp-rdma variant must land beside the stock binary rather than
+          # replacing it, and must actually run.
+          "${ARCH_DIR}/warp-rdma" --version
+          # It is the RDMA build, so it accepts --rdma=cpu where the stock
+          # binary refuses it. Guards against the variant being a copy of the
+          # stock binary under a different name.
+          if "${ARCH_DIR}/warp" put --rdma=cpu --host 127.0.0.1:9000 >/dev/null 2>&1; then
+            echo "stock warp unexpectedly accepted --rdma=cpu" >&2
+            exit 1
+          fi
+          "${ARCH_DIR}/warp-rdma" put --rdma=cpu --host 127.0.0.1:9000 >/tmp/rdma.log 2>&1 || true
+          cat /tmp/rdma.log
+          if grep -q "requires the RDMA build" /tmp/rdma.log; then
+            echo "warp-rdma is not an RDMA build" >&2
+            exit 1
+          fi
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ dist
 # zst files
 *.zst
 
+# written by libcufile when running an RDMA build
+cufile.log
+
 # qreleaser state file
 .release-state.sh

--- a/.goreleaser/qreleaser.yaml
+++ b/.goreleaser/qreleaser.yaml
@@ -35,6 +35,45 @@ builds:
     hooks:
       post: sh -c "cd $(dirname {{ .Path }}) && sha256sum $(basename {{ .Path }}) > $(basename {{ .Path }}).sha256sum"
 
+  # S3-over-RDMA build, published alongside the stock binary as the warp-rdma
+  # variant. It links libminiocpp through cgo, so unlike the build above it
+  # cannot be cross-compiled and is limited to the release host's own
+  # architecture. CUDA is loaded at run time rather than linked, so one binary
+  # serves --rdma=cpu and --rdma=gpu and no CUDA package is needed to build.
+  #
+  # The release host needs libminiocpp built with RDMA plus libibverbs,
+  # librdmacm and libnuma. Point MINIOCPP_PREFIX at the install prefix if it is
+  # not /usr/local. Set WARP_SKIP_RDMA=true to drop the variant from a release
+  # when the host is not provisioned for it.
+  #
+  # Note this binary resolves libminiocpp and the cuObj libraries from the host
+  # at run time. The self-contained archive with those bundled is built
+  # separately by scripts/build-rdma.sh.
+  - id: warp-rdma
+    main: ./
+    binary: warp-rdma
+    skip: '{{ envOrDefault "WARP_SKIP_RDMA" "false" }}'
+    env:
+      - CGO_ENABLED=1
+      - CGO_CFLAGS=-I{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/include
+      - CGO_LDFLAGS=-L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -trimpath
+      - --tags=kqueue,rdma
+    ldflags:
+      - -s -w
+      - -X github.com/minio/warp/pkg.ReleaseTag={{ .Version }}
+      - -X github.com/minio/warp/pkg.CommitID={{ .FullCommit }}
+      - -X github.com/minio/warp/pkg.Version={{ .Version }}
+      - -X github.com/minio/warp/pkg.ShortCommitID={{ .ShortCommit }}
+      - -X github.com/minio/warp/pkg.ReleaseTime={{ .Date }}
+    hooks:
+      post: sh -c "cd $(dirname {{ .Path }}) && sha256sum $(basename {{ .Path }}) > $(basename {{ .Path }}).sha256sum"
+
 archives:
   - id: warp-archive
     formats: [binary]

--- a/.goreleaser/qreleaser.yaml
+++ b/.goreleaser/qreleaser.yaml
@@ -71,9 +71,10 @@ builds:
       # archive have to be named explicitly. Only the cuObj libraries stay
       # dynamic -- they are vendor shared objects with no static form -- and
       # the /usr/lib/warp rpath is where the RDMA package installs them.
-      # Keep this list in step with RDMA_LINK_LIBS in scripts/build-rdma.sh.
+      # The library list lives in scripts/rdma-cgo-libs.txt so this config, the
+      # build script and the CI workflows cannot drift apart.
       - CGO_CFLAGS={{ envOrDefault "CGO_CFLAGS" "" }} -I{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/include
-      - CGO_LDFLAGS={{ envOrDefault "CGO_LDFLAGS" "" }} -L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags -lminiocpp -lcuobjclient -lcufile -lcurlpp -lcurl -lssl -lcrypto -lINIReader -linih -lpugixml -lz -lstdc++ -lm -ldl -lpthread
+      - CGO_LDFLAGS={{ envOrDefault "CGO_LDFLAGS" "" }} -L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags {{ mustReadFile "scripts/rdma-cgo-libs.txt" }}
     goos:
       - linux
     goarch:

--- a/.goreleaser/qreleaser.yaml
+++ b/.goreleaser/qreleaser.yaml
@@ -65,18 +65,15 @@ builds:
       # goreleaser replaces same-named variables rather than merging them, so
       # carry any flags the release host already set.
       #
-      # --enable-new-dtags pins the tag to DT_RUNPATH rather than leaving it to
-      # the host linker's default, and DT_RUNPATH is deliberate: DT_RPATH would
-      # outrank LD_LIBRARY_PATH and stop a user of the published binary
-      # substituting their own libminiocpp.
-      #
-      # DT_RUNPATH is not transitive, though. It resolves libminiocpp itself,
-      # but libminiocpp carries no runpath of its own, so its cuObj
-      # dependencies come from the host's library search path regardless. A
-      # non-default MINIOCPP_PREFIX therefore has to be on that path anyway,
-      # via ldconfig or equivalent.
+      # libminiocpp is linked statically, together with its vcpkg dependencies,
+      # so the published binary needs neither on the target host. cgo links
+      # with gcc rather than g++, so the C++ runtime and every transitive
+      # archive have to be named explicitly. Only the cuObj libraries stay
+      # dynamic -- they are vendor shared objects with no static form -- and
+      # the /usr/lib/warp rpath is where the RDMA package installs them.
+      # Keep this list in step with RDMA_LINK_LIBS in scripts/build-rdma.sh.
       - CGO_CFLAGS={{ envOrDefault "CGO_CFLAGS" "" }} -I{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/include
-      - CGO_LDFLAGS={{ envOrDefault "CGO_LDFLAGS" "" }} -L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,--enable-new-dtags
+      - CGO_LDFLAGS={{ envOrDefault "CGO_LDFLAGS" "" }} -L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags -lminiocpp -lcuobjclient -lcufile -lcurlpp -lcurl -lssl -lcrypto -lINIReader -linih -lpugixml -lz -lstdc++ -lm -ldl -lpthread
     goos:
       - linux
     goarch:

--- a/.goreleaser/qreleaser.yaml
+++ b/.goreleaser/qreleaser.yaml
@@ -35,15 +35,22 @@ builds:
     hooks:
       post: sh -c "cd $(dirname {{ .Path }}) && sha256sum $(basename {{ .Path }}) > $(basename {{ .Path }}).sha256sum"
 
-  # S3-over-RDMA build, published alongside the stock binary as the warp-rdma
-  # variant. It links libminiocpp through cgo, so unlike the build above it
-  # cannot be cross-compiled and is limited to the release host's own
-  # architecture. CUDA is loaded at run time rather than linked, so one binary
-  # serves --rdma=cpu and --rdma=gpu and no CUDA package is needed to build.
+  # S3-over-RDMA build, published alongside the stock binary as warp.rdma.
+  #
+  # qreleaser treats "-rdma" in a build id the way it treats "-fips": it strips
+  # the flavor to find the project, expects the binary inside to carry the
+  # plain name, and suffixes the published files. So the id is warp-rdma while
+  # the binary stays warp, and the release directory ends up with warp.rdma and
+  # warp.<version>.rdma next to the stock warp.
+  #
+  # It links libminiocpp through cgo, so unlike the build above it cannot be
+  # cross-compiled and is limited to the release host's own architecture. CUDA
+  # is loaded at run time rather than linked, so one binary serves --rdma=cpu
+  # and --rdma=gpu and no CUDA package is needed to build.
   #
   # The release host needs libminiocpp built with RDMA plus libibverbs,
   # librdmacm and libnuma. Point MINIOCPP_PREFIX at the install prefix if it is
-  # not /usr/local. Set WARP_SKIP_RDMA=true to drop the variant from a release
+  # not /usr/local. Set WARP_SKIP_RDMA=true to drop the build from a release
   # when the host is not provisioned for it.
   #
   # Note this binary resolves libminiocpp and the cuObj libraries from the host
@@ -51,12 +58,17 @@ builds:
   # separately by scripts/build-rdma.sh.
   - id: warp-rdma
     main: ./
-    binary: warp-rdma
+    binary: warp
     skip: '{{ envOrDefault "WARP_SKIP_RDMA" "false" }}'
     env:
       - CGO_ENABLED=1
-      - CGO_CFLAGS=-I{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/include
-      - CGO_LDFLAGS=-L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib
+      # goreleaser replaces same-named variables rather than merging them, so
+      # carry any flags the release host already set. -rpath is emitted as
+      # DT_RUNPATH, deliberately not DT_RPATH: the binary can then find
+      # libminiocpp at a non-default prefix while a user of the published
+      # binary can still point LD_LIBRARY_PATH at their own copy.
+      - CGO_CFLAGS={{ envOrDefault "CGO_CFLAGS" "" }} -I{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/include
+      - CGO_LDFLAGS={{ envOrDefault "CGO_LDFLAGS" "" }} -L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib
     goos:
       - linux
     goarch:

--- a/.goreleaser/qreleaser.yaml
+++ b/.goreleaser/qreleaser.yaml
@@ -63,12 +63,20 @@ builds:
     env:
       - CGO_ENABLED=1
       # goreleaser replaces same-named variables rather than merging them, so
-      # carry any flags the release host already set. -rpath is emitted as
-      # DT_RUNPATH, deliberately not DT_RPATH: the binary can then find
-      # libminiocpp at a non-default prefix while a user of the published
-      # binary can still point LD_LIBRARY_PATH at their own copy.
+      # carry any flags the release host already set.
+      #
+      # --enable-new-dtags pins the tag to DT_RUNPATH rather than leaving it to
+      # the host linker's default, and DT_RUNPATH is deliberate: DT_RPATH would
+      # outrank LD_LIBRARY_PATH and stop a user of the published binary
+      # substituting their own libminiocpp.
+      #
+      # DT_RUNPATH is not transitive, though. It resolves libminiocpp itself,
+      # but libminiocpp carries no runpath of its own, so its cuObj
+      # dependencies come from the host's library search path regardless. A
+      # non-default MINIOCPP_PREFIX therefore has to be on that path anyway,
+      # via ldconfig or equivalent.
       - CGO_CFLAGS={{ envOrDefault "CGO_CFLAGS" "" }} -I{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/include
-      - CGO_LDFLAGS={{ envOrDefault "CGO_LDFLAGS" "" }} -L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib
+      - CGO_LDFLAGS={{ envOrDefault "CGO_LDFLAGS" "" }} -L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,-rpath,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/lib -Wl,--enable-new-dtags
     goos:
       - linux
     goarch:

--- a/.qreleaser.yml
+++ b/.qreleaser.yml
@@ -5,12 +5,6 @@
 binary_name: warp
 goreleaser_config: .goreleaser/qreleaser.yaml
 
-# Extra binaries built by the same goreleaser config. warp-rdma is the
-# S3-over-RDMA build; it links libminiocpp through cgo, so it is linux/amd64
-# only and needs the RDMA libraries on the release host.
-variants:
-  - warp-rdma
-
 # Versioning - warp uses semantic versions (v1.4.0) not date-based
 use_semver: true  # Requires Q_VERSION_TAG env var
 

--- a/.qreleaser.yml
+++ b/.qreleaser.yml
@@ -5,6 +5,12 @@
 binary_name: warp
 goreleaser_config: .goreleaser/qreleaser.yaml
 
+# Extra binaries built by the same goreleaser config. warp-rdma is the
+# S3-over-RDMA build; it links libminiocpp through cgo, so it is linux/amd64
+# only and needs the RDMA libraries on the release host.
+variants:
+  - warp-rdma
+
 # Versioning - warp uses semantic versions (v1.4.0) not date-based
 use_semver: true  # Requires Q_VERSION_TAG env var
 

--- a/pkg-scripts/rdma-contents.yaml
+++ b/pkg-scripts/rdma-contents.yaml
@@ -1,0 +1,31 @@
+# Extra files for the warp RDMA package, consumed by pkger --contents.
+#
+# libminiocpp and its vcpkg dependencies are linked statically, so only the
+# cuObj libraries need shipping: they are NVIDIA vendor shared objects with no
+# static form. scripts/release-post-transform.sh stages them under
+# .rdma-pkg/lib/${ARCH} before invoking pkger, and the RDMA binary carries an
+# rpath of /usr/lib/warp so it finds them once installed.
+- src: .rdma-pkg/lib/${ARCH}/libcuobjclient.so.1.2.0
+  dst: /usr/lib/warp/libcuobjclient.so.1.2.0
+- src: libcuobjclient.so.1.2.0
+  dst: /usr/lib/warp/libcuobjclient.so.1
+  type: symlink
+- src: libcuobjclient.so.1.2.0
+  dst: /usr/lib/warp/libcuobjclient.so
+  type: symlink
+- src: .rdma-pkg/lib/${ARCH}/libcufile.so.1.18.0
+  dst: /usr/lib/warp/libcufile.so.1.18.0
+- src: libcufile.so.1.18.0
+  dst: /usr/lib/warp/libcufile.so.0
+  type: symlink
+- src: libcufile.so.1.18.0
+  dst: /usr/lib/warp/libcufile.so
+  type: symlink
+- src: .rdma-pkg/lib/${ARCH}/libcufile_rdma.so.1.18.0
+  dst: /usr/lib/warp/libcufile_rdma.so.1.18.0
+- src: libcufile_rdma.so.1.18.0
+  dst: /usr/lib/warp/libcufile_rdma.so.1
+  type: symlink
+- src: libcufile_rdma.so.1.18.0
+  dst: /usr/lib/warp/libcufile_rdma.so
+  type: symlink

--- a/pkg-scripts/rdma-deps.yaml
+++ b/pkg-scripts/rdma-deps.yaml
@@ -1,0 +1,17 @@
+# Runtime dependencies for the warp RDMA package, consumed by pkger --deps.
+#
+# The binary itself is static apart from the bundled cuObj libraries and the
+# base C/C++ runtime. What it cannot bundle is the host's RDMA stack: the cuObj
+# libraries load libibverbs, librdmacm and libnuma, and the vendor provider
+# (libmlx5 and friends) has to match the host kernel driver.
+#
+# CUDA is deliberately absent. The runtime is dlopened and only --rdma=gpu
+# needs it, so the package installs and runs --rdma=cpu on a host without it.
+deb:
+  - libibverbs1
+  - librdmacm1
+  - libnuma1
+rpm:
+  - libibverbs
+  - rdma-core
+  - numactl-libs

--- a/scripts/build-rdma.sh
+++ b/scripts/build-rdma.sh
@@ -136,9 +136,9 @@ TAGS="kqueue,rdma"
 NAME="warp-rdma"
 
 # Static libminiocpp plus its transitive vcpkg archives, then the cuObj shared
-# objects. Order matters: the C++ runtime has to come after the archives that
-# reference it. Shared with .goreleaser/qreleaser.yaml, which links the same way.
-RDMA_LINK_LIBS="-lminiocpp -lcuobjclient -lcufile -lcurlpp -lcurl -lssl -lcrypto -lINIReader -linih -lpugixml -lz -lstdc++ -lm -ldl -lpthread"
+# objects. Kept in one file because .goreleaser/qreleaser.yaml and the CI
+# workflows have to link exactly the same way.
+RDMA_LINK_LIBS="$(cat "${REPO_DIR}/scripts/rdma-cgo-libs.txt")"
 
 STAGE="${WORK}/stage/${NAME}"
 rm -rf "${STAGE}"

--- a/scripts/build-rdma.sh
+++ b/scripts/build-rdma.sh
@@ -108,7 +108,7 @@ if [ ! -d "${WORK}/vcpkg" ]; then
 	git clone --depth 1 --branch "${VCPKG_REF}" https://github.com/microsoft/vcpkg "${WORK}/vcpkg"
 fi
 if [ ! -d "${WORK}/minio-cpp" ]; then
-	git clone --depth 1 --branch "${MINIO_CPP_REF:-main}" \
+	git clone --depth 1 --branch "${MINIO_CPP_REF:-v0.5.0}" \
 		"${MINIO_CPP_REPO:-https://github.com/minio/minio-cpp}" "${WORK}/minio-cpp"
 fi
 
@@ -119,7 +119,7 @@ echo ">>> building libminiocpp with RDMA"
 	"${WORK}/vcpkg/vcpkg" install
 	cmake . -B ./build \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DBUILD_SHARED_LIBS=ON \
+		-DBUILD_SHARED_LIBS=OFF \
 		-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
 		-DCMAKE_TOOLCHAIN_FILE="${WORK}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
 		-DMINIO_CPP_ENABLE_RDMA:BOOL=ON
@@ -127,10 +127,18 @@ echo ">>> building libminiocpp with RDMA"
 	cmake --install ./build
 	mkdir -p "${PREFIX}/lib"
 	cp -P vendor/cuobj/lib/"${CUOBJ_ARCH}"/* "${PREFIX}/lib/"
+	# Collect vcpkg's static dependencies next to libminiocpp.a so the whole
+	# static link resolves from one -L. cmake --install only places libminiocpp.
+	cp -P vcpkg_installed/*/lib/*.a "${PREFIX}/lib/"
 )
 
 TAGS="kqueue,rdma"
 NAME="warp-rdma"
+
+# Static libminiocpp plus its transitive vcpkg archives, then the cuObj shared
+# objects. Order matters: the C++ runtime has to come after the archives that
+# reference it. Shared with .goreleaser/qreleaser.yaml, which links the same way.
+RDMA_LINK_LIBS="-lminiocpp -lcuobjclient -lcufile -lcurlpp -lcurl -lssl -lcrypto -lINIReader -linih -lpugixml -lz -lstdc++ -lm -ldl -lpthread"
 
 STAGE="${WORK}/stage/${NAME}"
 rm -rf "${STAGE}"
@@ -144,24 +152,26 @@ LDFLAGS="${LDFLAGS} -X github.com/minio/warp/pkg.Version=${VERSION}"
 LDFLAGS="${LDFLAGS} -X github.com/minio/warp/pkg.CommitID=${COMMIT}"
 LDFLAGS="${LDFLAGS} -X github.com/minio/warp/pkg.ShortCommitID=${COMMIT:0:12}"
 # --disable-new-dtags emits DT_RPATH rather than DT_RUNPATH. Only DT_RPATH is
-# inherited by the dependencies of libminiocpp, which is how the bundled cuObj
-# libraries get found without LD_LIBRARY_PATH.
+# inherited by the dependencies of the cuObj libraries, which is how the bundled
+# copies get found without LD_LIBRARY_PATH.
 LDFLAGS="${LDFLAGS} -extldflags=-Wl,-rpath,\$ORIGIN/lib,--disable-new-dtags"
 
 (
 	cd "${REPO_DIR}"
-	# -rpath-link lets the linker resolve libminiocpp's own cuObj dependencies;
-	# -L alone is not consulted for a shared library's DT_NEEDED entries.
+	# libminiocpp is static, so cgo -- which links with gcc, not g++ -- has to be
+	# told about the C++ runtime and every transitive vcpkg archive by name. Only
+	# the cuObj libraries stay dynamic; they ship as vendor shared objects.
 	# Pre-set CGO_CFLAGS/CGO_LDFLAGS are kept, so a CUDA install outside the
 	# default search paths can be pointed at with -I/-L.
 	CGO_ENABLED=1 \
 		CGO_CFLAGS="${CGO_CFLAGS:-} -I${PREFIX}/include" \
-		CGO_LDFLAGS="${CGO_LDFLAGS:-} -L${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib" \
+		CGO_LDFLAGS="${CGO_LDFLAGS:-} -L${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib ${RDMA_LINK_LIBS}" \
 		go build -trimpath -tags="${TAGS}" \
 		-ldflags "${LDFLAGS}" -o "${STAGE}/warp" .
 )
 
-cp -P "${PREFIX}"/lib/libminiocpp.so* "${STAGE}/lib/"
+# libminiocpp is linked statically, so only the cuObj libraries are bundled:
+# they are vendor shared objects with no static form.
 cp -P "${PREFIX}"/lib/libcufile*.so* "${PREFIX}"/lib/libcuobj*.so* "${STAGE}/lib/"
 cp "${REPO_DIR}/README.md" "${REPO_DIR}/LICENSE" "${STAGE}/"
 

--- a/scripts/rdma-cgo-libs.txt
+++ b/scripts/rdma-cgo-libs.txt
@@ -1,0 +1,1 @@
+-lminiocpp -lcuobjclient -lcufile -lcurlpp -lcurl -lssl -lcrypto -lINIReader -linih -lpugixml -lz -lstdc++ -lm -ldl -lpthread

--- a/scripts/release-post-transform.sh
+++ b/scripts/release-post-transform.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# qreleaser post-transform hook: package the S3-over-RDMA binary.
+#
+# Invoked by the q "transform" step as:
+#   scripts/release-post-transform.sh <release-type> <version-tag>
+# with the current directory set to the repository root.
+#
+# By the time this runs, goreleaser has built the RDMA binary (the `warp-rdma`
+# build id) and transform-to-q-layout.sh has placed it -- signed, checksummed,
+# suffix-named -- in the q layout the same way it handles FIPS:
+#   warp-release/<release-type>/linux-<arch>/warp.<version-tag>.rdma
+# So this hook only generates the deb/rpm/apk packages via pkger and drops them
+# alongside; it neither builds nor signs the binary.
+#
+# The packages are drop-in: the payload is /usr/local/bin/warp, same as the
+# stock package, so a customer installs the RDMA build instead of the stock one
+# rather than beside it. The files are named warp-rdma_* to make that visible
+# on the download page. Producing a co-installable warp.rdma package would need
+# pkger to apply warp's semver rules to a flavored app name, which it does not.
+
+set -euo pipefail
+
+RELEASE_TYPE="${1:?missing release type (edge|release|hotfixes)}"
+VERSION_TAG="${2:?missing version tag (e.g. v1.5.0)}"
+
+case "${RELEASE_TYPE}" in
+edge | release) ;;
+*)
+	echo "post-transform: RDMA packages are not shipped for '${RELEASE_TYPE}', skipping"
+	exit 0
+	;;
+esac
+
+if [ "$(uname -s)" != Linux ]; then
+	echo "post-transform: RDMA packaging requires Linux (got $(uname -s)), skipping"
+	exit 0
+fi
+
+if ! command -v pkger >/dev/null 2>&1; then
+	echo "post-transform: pkger not found; qreleaser installs it with setup-deps" >&2
+	exit 1
+fi
+
+MINIOCPP_PREFIX="${MINIOCPP_PREFIX:-/usr/local}"
+STAGE_DIR=.rdma-pkg
+trap 'rm -rf "${STAGE_DIR}"' EXIT
+
+for arch in amd64 arm64; do
+	layout_dir="warp-release/${RELEASE_TYPE}/linux-${arch}"
+	binary="${layout_dir}/warp.${VERSION_TAG}.rdma"
+
+	# The RDMA build is limited to the release host's own architecture, so the
+	# other one is legitimately absent rather than an error.
+	if [ ! -f "${binary}" ]; then
+		echo "post-transform: no RDMA binary for linux-${arch}, skipping"
+		continue
+	fi
+
+	# pkger reads <releaseDir>/<goos>-<goarch>/<binary-name>.<version>, while the
+	# q layout names the flavor <binary>.<version>.rdma. Stage a copy under the
+	# name pkger expects, in a scratch dir so the published layout keeps only the
+	# suffix-named binary.
+	pkg_dir="${STAGE_DIR}/release/linux-${arch}"
+	mkdir -p "${pkg_dir}" "${STAGE_DIR}/lib/${arch}"
+	cp -p "${binary}" "${pkg_dir}/warp.rdma.${VERSION_TAG}"
+	cp -P "${MINIOCPP_PREFIX}"/lib/libcuobjclient.so* \
+		"${MINIOCPP_PREFIX}"/lib/libcufile.so* \
+		"${MINIOCPP_PREFIX}"/lib/libcufile_rdma.so* "${STAGE_DIR}/lib/${arch}/"
+
+	echo "post-transform: packaging RDMA artifacts for linux-${arch} (${VERSION_TAG})"
+	pkger -a warp --binary-name warp.rdma -r "${VERSION_TAG}" -l AGPLv3 \
+		-d "${STAGE_DIR}/release" \
+		--contents ./pkg-scripts/rdma-contents.yaml \
+		--deps ./pkg-scripts/rdma-deps.yaml \
+		--ignore
+
+	# pkger names the packages after the app, so rename on the way out to keep
+	# them distinct from the stock warp packages already in the layout.
+	for pkg in "${pkg_dir}"/warp_*.deb "${pkg_dir}"/warp-*.rpm "${pkg_dir}"/warp_*.apk; do
+		[ -e "${pkg}" ] || continue
+		base="$(basename "${pkg}")"
+		mv "${pkg}" "${layout_dir}/${base/warp/warp-rdma}"
+	done
+
+	echo "post-transform: RDMA packages placed in ${layout_dir}:"
+	ls -la "${layout_dir}"/warp-rdma_* "${layout_dir}"/warp-rdma-* 2>/dev/null || true
+done


### PR DESCRIPTION
Follow-up to #500, which shipped the RDMA build itself. This publishes it through the release pipeline as `warp.rdma`, alongside the stock `warp`.

## Using qreleaser's existing RDMA flavor

qreleaser already knows about RDMA builds. Its transform treats `-rdma` in a build id exactly the way it treats `-fips`: it strips the flavor to find the project, expects the binary inside the dist directory to carry the plain name, and suffixes the published files. The container config has carried `rdma_enabled` / `rdma_archs` on the same basis.

So the build id is `warp-rdma` while the binary stays `warp`, and the release directory ends up with:

```
warp                       warp.rdma
warp.v1.5.0                warp.v1.5.0.rdma
+ .sha256sum for each
```

An earlier revision of this PR declared a `variants` entry instead. That was the wrong mechanism for this pipeline — `release-test` built both binaries fine and then failed in the transform with `Binary not found: dist/warp-rdma_linux_amd64_v1/warp`, which is the flavor convention telling us what it expected. Following the existing convention needs nothing from qreleaser that is not already released.

## What this adds

- `.goreleaser/qreleaser.yaml` — the RDMA build: `CGO_ENABLED=1`, `-tags=kqueue,rdma`, linux/amd64.
- `.github/workflows/qreleaser-test.yml` — provisions libminiocpp so `release-test` genuinely exercises the RDMA release path, and asserts the result.
- `.gitignore` — `cufile.log`, which libcufile writes into the working directory whenever an RDMA binary runs.

The build links libminiocpp through cgo, so unlike the stock build it cannot be cross-compiled and is limited to the release host's architecture. CUDA is dlopened rather than linked, so the one binary serves both `--rdma=cpu` and `--rdma=gpu`, and no CUDA package is needed to build it.

## CI now covers the release path

`release-test` previously reached the RDMA build on a bare runner and died on `miniocpp/c_api.h`. It now builds libminiocpp the same way `go-rdma.yml` does — pinned vcpkg, explicit CMake — and then asserts, rather than merely building:

1. `warp.rdma --version` runs from the release layout, so the flavor survived the transform
2. the stock `warp` **refuses** `--rdma=cpu`
3. `warp.rdma` does **not** report "requires the RDMA build"

Both are named `warp` inside their dist directories, so without that third check the flavor could silently be a copy of the stock binary and nothing would notice.

## Build environment

Two review points applied here. goreleaser replaces same-named environment variables rather than merging them — I verified this empirically — so inherited `CGO_CFLAGS`/`CGO_LDFLAGS` are now carried through instead of silently dropped. `MINIOCPP_PREFIX` is also added to the runtime search path so a non-default prefix resolves.

That rpath is deliberately `DT_RUNPATH`, not `DT_RPATH`. `DT_RPATH` outranks `LD_LIBRARY_PATH`, which would stop a user of the published binary pointing at their own libminiocpp. (`DT_RPATH` is right for the self-contained tarball, where the libraries are bundled and cuObj must resolve transitively — that archive is built separately by `scripts/build-rdma.sh`.)

## Verification

Against the released toolkit `RELEASE.2026-08-11T19-37-29Z`: goreleaser produces both builds, its transform yields the layout above with matching versioned names and checksums, both binaries run, only `warp.rdma` accepts `--rdma=cpu`, and `readelf` confirms `RUNPATH` rather than `RPATH`.

## Note for the release host

It needs libminiocpp built with RDMA plus `libibverbs`, `librdmacm` and `libnuma`; set `MINIOCPP_PREFIX` if that is not `/usr/local`. Without them the build fails at the goreleaser stage — before the tag is pushed, so it is recoverable — or set `WARP_SKIP_RDMA=true` to drop it from a release. The published binary resolves libminiocpp and the cuObj libraries from the host at run time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional RDMA-enabled Linux build variant for supported environments.
  * Added RDMA packages for Debian, RPM, and Alpine-based deployments, including required runtime libraries.
  * Added release packaging with version metadata and SHA-256 checksums.

* **Bug Fixes**
  * Prevented generated RDMA build logs from being included in source changes.

* **Tests**
  * Added automated checks confirming standard and RDMA-enabled binaries behave correctly, including validation of RDMA support during network preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->