### PR TITLE
docs: add an RDMA guide, and give the RDMA packages checksums

### DIFF
--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -3,10 +3,10 @@ name: Build (RDMA)
 on:
   pull_request:
     branches:
-    - master
+      - master
   push:
     branches:
-    - master
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -23,88 +23,88 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: ubuntu-latest,    arch: "amd64" }
-        - { os: ubuntu-24.04-arm, arch: "arm64" }
+          - { os: ubuntu-latest, arch: "amd64" }
+          - { os: ubuntu-24.04-arm, arch: "arm64" }
 
     steps:
-    - name: Checkout warp
-      uses: actions/checkout@v5
-      with:
-        path: "warp"
-        persist-credentials: false
+      - name: Checkout warp
+        uses: actions/checkout@v5
+        with:
+          path: "warp"
+          persist-credentials: false
 
-    - name: Checkout minio-cpp
-      uses: actions/checkout@v5
-      with:
-        repository: minio/minio-cpp
-        path: "minio-cpp"
-        persist-credentials: false
+      - name: Checkout minio-cpp
+        uses: actions/checkout@v5
+        with:
+          repository: minio/minio-cpp
+          path: "minio-cpp"
+          persist-credentials: false
 
-    # Pinned: vcpkg's port scripts track the newest CMake, and a floating
-    # checkout breaks against whatever CMake the runner image ships.
-    - name: Checkout vcpkg
-      uses: actions/checkout@v5
-      with:
-        repository: microsoft/vcpkg
-        ref: "2026.07.29"
-        path: "vcpkg"
-        persist-credentials: false
+      # Pinned: vcpkg's port scripts track the newest CMake, and a floating
+      # checkout breaks against whatever CMake the runner image ships.
+      - name: Checkout vcpkg
+        uses: actions/checkout@v5
+        with:
+          repository: microsoft/vcpkg
+          ref: "2026.07.29"
+          path: "vcpkg"
+          persist-credentials: false
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get -qy update
-        sudo apt-get -qy install libibverbs-dev librdmacm-dev libnuma-dev
+      - name: Install system dependencies
+        run: |
+          sudo apt-get -qy update
+          sudo apt-get -qy install libibverbs-dev librdmacm-dev libnuma-dev
 
-    # Ubuntu's cmake is older than vcpkg needs, and vcpkg does not fetch its
-    # own on arm64, so provision it explicitly on both architectures.
-    - name: Set up CMake
-      uses: lukka/get-cmake@v4.4.2
+      # Ubuntu's cmake is older than vcpkg needs, and vcpkg does not fetch its
+      # own on arm64, so provision it explicitly on both architectures.
+      - name: Set up CMake
+        uses: lukka/get-cmake@v4.4.2
 
-    - name: Build and install libminiocpp.so with RDMA
-      shell: bash
-      run: |
-        ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
-        cd minio-cpp
-        ../vcpkg/vcpkg install
-        cmake . -B ./build \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DCMAKE_INSTALL_PREFIX=/usr/local \
-          -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
-          -DMINIO_CPP_ENABLE_RDMA:BOOL=ON
-        cmake --build ./build --config Release -j 4
-        sudo cmake --install ./build
-        cuobj_arch=$([ "${{ matrix.config.arch }}" = "amd64" ] && echo x86_64 || echo aarch64)
-        sudo cp -P vendor/cuobj/lib/${cuobj_arch}/* /usr/local/lib/
-        # libminiocpp is static; its vcpkg archives must sit beside it to link.
-        sudo cp -P vcpkg_installed/*/lib/*.a /usr/local/lib/
-        sudo ldconfig
+      - name: Build and install libminiocpp.so with RDMA
+        shell: bash
+        run: |
+          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          cd minio-cpp
+          ../vcpkg/vcpkg install
+          cmake . -B ./build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DMINIO_CPP_ENABLE_RDMA:BOOL=ON
+          cmake --build ./build --config Release -j 4
+          sudo cmake --install ./build
+          cuobj_arch=$([ "${{ matrix.config.arch }}" = "amd64" ] && echo x86_64 || echo aarch64)
+          sudo cp -P vendor/cuobj/lib/${cuobj_arch}/* /usr/local/lib/
+          # libminiocpp is static; its vcpkg archives must sit beside it to link.
+          sudo cp -P vcpkg_installed/*/lib/*.a /usr/local/lib/
+          sudo ldconfig
 
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version-file: "warp/go.mod"
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "warp/go.mod"
 
-    - name: Build and vet with -tags=rdma
-      working-directory: warp
-      env:
-        CGO_ENABLED: "1"
-      run: |
-        # libminiocpp is static, so minio-go's own -lminiocpp no longer drags in
-        # the C++ runtime or the vcpkg archives; name them from the one list the
-        # build script and goreleaser config also use.
-        export CGO_LDFLAGS="-L/usr/local/lib $(cat scripts/rdma-cgo-libs.txt)"
-        go build -tags=rdma -o /tmp/warp .
-        go vet -tags=rdma ./...
-        go test -race -tags=rdma ./...
-        /tmp/warp --version
-        # CUDA is dlopened, so the binary must still start on this CUDA-less
-        # runner and reject --rdma=gpu with a diagnosis rather than failing to
-        # load. This is the property that lets one binary serve both modes.
-        if /tmp/warp put --rdma=gpu --host 127.0.0.1:9000 >/tmp/gpu.log 2>&1; then
-          echo "expected --rdma=gpu to fail on a host without CUDA" >&2
+      - name: Build and vet with -tags=rdma
+        working-directory: warp
+        env:
+          CGO_ENABLED: "1"
+        run: |
+          # libminiocpp is static, so minio-go's own -lminiocpp no longer drags in
+          # the C++ runtime or the vcpkg archives; name them from the one list the
+          # build script and goreleaser config also use.
+          export CGO_LDFLAGS="-L/usr/local/lib $(cat scripts/rdma-cgo-libs.txt)"
+          go build -tags=rdma -o /tmp/warp .
+          go vet -tags=rdma ./...
+          go test -race -tags=rdma ./...
+          /tmp/warp --version
+          # CUDA is dlopened, so the binary must still start on this CUDA-less
+          # runner and reject --rdma=gpu with a diagnosis rather than failing to
+          # load. This is the property that lets one binary serve both modes.
+          if /tmp/warp put --rdma=gpu --host 127.0.0.1:9000 >/tmp/gpu.log 2>&1; then
+            echo "expected --rdma=gpu to fail on a host without CUDA" >&2
+            cat /tmp/gpu.log
+            exit 1
+          fi
           cat /tmp/gpu.log
-          exit 1
-        fi
-        cat /tmp/gpu.log
-        grep -q "CUDA runtime" /tmp/gpu.log
+          grep -q "CUDA runtime" /tmp/gpu.log

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,10 +3,10 @@ name: Go
 on:
   pull_request:
     branches:
-    - master
+      - master
   push:
     branches:
-    - master
+      - master
 
 jobs:
   build:

--- a/.github/workflows/qreleaser-test.yml
+++ b/.github/workflows/qreleaser-test.yml
@@ -169,6 +169,14 @@ jobs:
           fi
           grep -q "Error preparing server" /tmp/rdma.log
 
+          # The post-transform hook renames the packages after pkger builds
+          # them, so their checksums are regenerated rather than carried over.
+          # Verify them, and fail if the flavor produced none at all.
+          ls "${ARCH_DIR}"/warp-rdma*.sha256sum >/dev/null
+          for f in "${ARCH_DIR}"/warp-rdma*.sha256sum; do
+            (cd "${ARCH_DIR}" && sha256sum -c "$(basename "${f}")")
+          done
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/qreleaser-test.yml
+++ b/.github/workflows/qreleaser-test.yml
@@ -171,11 +171,19 @@ jobs:
 
           # The post-transform hook renames the packages after pkger builds
           # them, so their checksums are regenerated rather than carried over.
-          # Verify them, and fail if the flavor produced none at all.
-          ls "${ARCH_DIR}"/warp-rdma*.sha256sum >/dev/null
-          for f in "${ARCH_DIR}"/warp-rdma*.sha256sum; do
-            (cd "${ARCH_DIR}" && sha256sum -c "$(basename "${f}")")
+          # Walk the packages rather than the manifests, so a package that lost
+          # its checksum fails here instead of passing unnoticed.
+          found=0
+          for pkg in "${ARCH_DIR}"/warp-rdma*.deb \
+                     "${ARCH_DIR}"/warp-rdma*.rpm \
+                     "${ARCH_DIR}"/warp-rdma*.apk; do
+            [ -e "${pkg}" ] || continue
+            found=1
+            # sha256sum -c fails when the manifest is missing, so this also
+            # requires every package to have one.
+            (cd "${ARCH_DIR}" && sha256sum -c "$(basename "${pkg}").sha256sum")
           done
+          [ "${found}" = 1 ] || { echo "no RDMA packages in ${ARCH_DIR}" >&2; exit 1; }
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-rdma.yml
+++ b/.github/workflows/release-rdma.yml
@@ -8,7 +8,7 @@ name: Release (RDMA)
 on:
   push:
     tags:
-    - 'v*'
+      - "v*"
   workflow_dispatch:
     inputs:
       tag:
@@ -34,65 +34,65 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: ubuntu-latest,    arch: "amd64" }
-        - { os: ubuntu-24.04-arm, arch: "arm64" }
+          - { os: ubuntu-latest, arch: "amd64" }
+          - { os: ubuntu-24.04-arm, arch: "arm64" }
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v5
-      with:
-        ref: ${{ inputs.tag || github.ref }}
-        fetch-depth: 0
-        persist-credentials: false
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get -qy update
-        sudo apt-get -qy install libibverbs-dev librdmacm-dev libnuma-dev
+      - name: Install system dependencies
+        run: |
+          sudo apt-get -qy update
+          sudo apt-get -qy install libibverbs-dev librdmacm-dev libnuma-dev
 
-    # Ubuntu's cmake is older than vcpkg needs, and vcpkg does not fetch its
-    # own on arm64, so provision it explicitly on both architectures.
-    - name: Set up CMake
-      uses: lukka/get-cmake@v4.4.2
+      # Ubuntu's cmake is older than vcpkg needs, and vcpkg does not fetch its
+      # own on arm64, so provision it explicitly on both architectures.
+      - name: Set up CMake
+        uses: lukka/get-cmake@v4.4.2
 
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version-file: "go.mod"
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
 
-    - name: Build RDMA release artifact
-      env:
-        VERSION: ${{ inputs.tag || github.ref_name }}
-      run: |
-        ./scripts/build-rdma.sh \
-          --version "${VERSION}" \
-          --out "${GITHUB_WORKSPACE}/dist-rdma"
+      - name: Build RDMA release artifact
+        env:
+          VERSION: ${{ inputs.tag || github.ref_name }}
+        run: |
+          ./scripts/build-rdma.sh \
+            --version "${VERSION}" \
+            --out "${GITHUB_WORKSPACE}/dist-rdma"
 
-    - name: Upload artifact to workflow run
-      uses: actions/upload-artifact@v4
-      with:
-        name: warp-rdma-linux-${{ matrix.config.arch }}
-        path: dist-rdma/
+      - name: Upload artifact to workflow run
+        uses: actions/upload-artifact@v4
+        with:
+          name: warp-rdma-linux-${{ matrix.config.arch }}
+          path: dist-rdma/
 
-    - name: Attach artifact to release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ inputs.tag || github.ref_name }}
-        REPO: ${{ github.repository }}
-      run: |
-        # The release for this tag is created by the main release pipeline,
-        # which may still be running. Wait for it before uploading, and keep
-        # retrying a failed upload rather than letting bash -e end the job.
-        for i in $(seq 1 30); do
-          if gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
-            if gh release upload "${TAG}" dist-rdma/* --clobber --repo "${REPO}"; then
-              exit 0
+      - name: Attach artifact to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          # The release for this tag is created by the main release pipeline,
+          # which may still be running. Wait for it before uploading, and keep
+          # retrying a failed upload rather than letting bash -e end the job.
+          for i in $(seq 1 30); do
+            if gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+              if gh release upload "${TAG}" dist-rdma/* --clobber --repo "${REPO}"; then
+                exit 0
+              fi
+              echo "upload failed, retrying in 60s ($i/30)" >&2
+            else
+              echo "release ${TAG} not published yet, retrying in 60s ($i/30)"
             fi
-            echo "upload failed, retrying in 60s ($i/30)" >&2
-          else
-            echo "release ${TAG} not published yet, retrying in 60s ($i/30)"
-          fi
-          sleep 60
-        done
-        echo "release ${TAG} never appeared; artifacts are attached to this workflow run" >&2
-        exit 1
+            sleep 60
+          done
+          echo "release ${TAG} never appeared; artifacts are attached to this workflow run" >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,47 +2,40 @@ name: goreleaser
 
 on:
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
     branches:
-      - 'master'
+      - "master"
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v5
-      -
-        name: Unshallow
+      - name: Unshallow
         run: git fetch --prune --unshallow
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.25.x
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --clean --skip=publish --snapshot
-      -
-        name: Upload Win64 Binaries
+      - name: Upload Win64 Binaries
         uses: actions/upload-artifact@v4
         if: success()
         with:
           name: Warp-Snapshot-Build-Win64
           path: dist/warp_windows_amd64_v1
-      -
-        name: Upload Linux Binaries
+      - name: Upload Linux Binaries
         uses: actions/upload-artifact@v4
         if: success()
         with:
           name: Warp-Snapshot-Build-Linux-amd64
           path: dist/warp_linux_amd64_v1
-      -
-        name: Upload MacOS Binaries
+      - name: Upload MacOS Binaries
         uses: actions/upload-artifact@v4
         if: success()
         with:

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -2,29 +2,29 @@ name: VulnCheck
 on:
   pull_request:
     branches:
-    - master
-    - main
+      - master
+      - main
   push:
     branches:
-    - master
-    - main
+      - master
+      - main
 jobs:
   vulncheck:
     name: Analysis
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.26.x ]
+        go-version: [1.26.x]
     steps:
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v5
-    - uses: actions/setup-go@v6
-      with:
-        go-version: ${{ matrix.go-version }}
-        check-latest: true
-    - name: Get govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
-      shell: bash
-    - name: Run govulncheck
-      run: govulncheck ./...
-      shell: bash
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+      - name: Get govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        shell: bash
+      - name: Run govulncheck
+        run: govulncheck ./...
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cufile.log
 
 # qreleaser state file
 .release-state.sh
+warp-release/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,7 @@
 project_name: warp
 
 builds:
-  -
-    goos:
+  - goos:
       - freebsd
       - windows
       - linux
@@ -23,8 +22,7 @@ builds:
     ldflags:
       - -s -w -X github.com/minio/warp/pkg.ReleaseTag={{.Tag}} -X github.com/minio/warp/pkg.CommitID={{.FullCommit}} -X github.com/minio/warp/pkg.Version={{.Version}} -X github.com/minio/warp/pkg.ShortCommitID={{.ShortCommit}} -X github.com/minio/warp/pkg.ReleaseTime={{.Date}}
 archives:
-  -
-    name_template: >-
+  - name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
@@ -38,18 +36,17 @@ archives:
       - LICENSE
       - warp_logo.png
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: 'snapshot-{{ time "2006-01-02" }}'
 changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"
 nfpms:
-  -
-    vendor: MinIO Inc.
+  - vendor: MinIO Inc.
     homepage: https://github.com/minio/warp
     maintainer: MinIO <minio@minio.io>
     description: S3 API Benchmark Tool
@@ -68,8 +65,7 @@ nfpms:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
 dockers:
-  -
-    # GOOS of the built binary that should be used.
+  - # GOOS of the built binary that should be used.
     goos: linux
     # GOARCH of the built binary that should be used.
     goarch: amd64

--- a/.qreleaser.yml
+++ b/.qreleaser.yml
@@ -6,10 +6,10 @@ binary_name: warp
 goreleaser_config: .goreleaser/qreleaser.yaml
 
 # Versioning - warp uses semantic versions (v1.4.0) not date-based
-use_semver: true  # Requires Q_VERSION_TAG env var
+use_semver: true # Requires Q_VERSION_TAG env var
 
 # Distribution
-dl_upload_enabled: true  # Upload binaries to dl.min.io
+dl_upload_enabled: true # Upload binaries to dl.min.io
 
 # Container images
 containers:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Warp is a high-performance S3 benchmarking tool for testing object storage syste
 ## Build and Test Commands
 
 ### Building
+
 ```bash
 # Build the binary
 go build
@@ -25,6 +26,7 @@ dependencies and packages the tarball; `.github/workflows/go-rdma.yml` keeps the
 tagged build compiling.
 
 ### Testing
+
 ```bash
 # Run all tests with race detection
 go test -v -race ./...
@@ -35,6 +37,7 @@ go test -v ./pkg/aggregate
 ```
 
 ### Linting and Formatting
+
 ```bash
 # Run golangci-lint (requires installation)
 golangci-lint run --timeout=5m --config ./.golangci.yml
@@ -72,10 +75,12 @@ gofmt -w .
 The packages follow a layered dependency structure:
 
 **pkg/generator/** - Test data generation (base package with no warp dependencies)
+
 - Random data generation for benchmark objects
 - Supports fixed size, random sizes, and bucketed sizes
 
 **pkg/bench/** - Benchmark implementations (imports pkg/generator)
+
 - `benchmark.go` - Core `Benchmark` interface with `Prepare()`, `Start()`, `Cleanup()` methods
 - `Common` struct contains shared configuration (bucket, concurrency, clients, etc.)
 - Each operation type implements the Benchmark interface (get.go, put.go, mixed.go, etc.)
@@ -83,6 +88,7 @@ The packages follow a layered dependency structure:
 - `collector.go` - Real-time operation statistics collection
 
 **pkg/aggregate/** - Data aggregation and analysis (imports pkg/bench)
+
 - `aggregate.go` - Aggregates raw operation data into statistics
 - `throughput.go` - Throughput calculations and statistics
 - `requests.go` - Per-request statistics (latency, TTFB, percentiles)
@@ -90,9 +96,11 @@ The packages follow a layered dependency structure:
 - `live.go` - Live statistics updates during benchmark runs
 
 **api/** - HTTP API for benchmark status and control (imports pkg/bench and pkg/aggregate)
+
 - `api.go` - Provides HTTP endpoints for monitoring running benchmarks
 
 **cli/** - Command-line interface layer (imports api, pkg/aggregate, pkg/bench, pkg/generator)
+
 - Each benchmark type has its own file (get.go, put.go, delete.go, etc.)
 - `benchmark.go` - Main benchmark execution logic (`runBench`, `runServerBenchmark`, `runClientBenchmark`)
 - `benchserver.go` / `benchclient.go` - Distributed benchmarking coordination
@@ -104,6 +112,7 @@ The packages follow a layered dependency structure:
 ### Key Patterns
 
 **Benchmark Execution Flow:**
+
 1. CLI parses flags and creates benchmark instance
 2. `Prepare()` - Creates buckets, uploads initial objects if needed
 3. `Start()` - Runs concurrent operations until duration expires or autoterm triggers
@@ -112,6 +121,7 @@ The packages follow a layered dependency structure:
 6. Analysis runs on recorded data, outputs statistics
 
 **Distributed Benchmarking:**
+
 - Server mode: Coordinates multiple clients, merges their results
 - Client mode: Runs `warp client [address]` to listen for benchmark commands
 - Server sends benchmark configuration to all clients
@@ -119,6 +129,7 @@ The packages follow a layered dependency structure:
 - Results collected and merged by server
 
 **Operation Collection:**
+
 - Each operation creates an `Operation` struct with timing, size, endpoint, error info
 - Sent to `Collector` which batches and compresses to `.csv.zst` files
 - Format: Tab-separated values with fields like idx, thread, op, client_id, n_objects, bytes, etc.
@@ -142,12 +153,14 @@ The packages follow a layered dependency structure:
 ### Testing S3 Compatibility
 
 Warp is designed to test any S3-compatible storage. Connection configured via:
+
 - Flags: `--host`, `--access-key`, `--secret-key`, `--tls`, `--region`
 - Environment: `WARP_HOST`, `WARP_ACCESS_KEY`, `WARP_SECRET_KEY`, `WARP_TLS`, `WARP_REGION`
 
 ### YAML Configuration
 
 Benchmarks can be configured via YAML files in `yml-samples/`. Run with:
+
 ```bash
 warp run <file.yml>
 ```
@@ -157,6 +170,7 @@ Variables can be injected: `warp run file.yml -var VarName=Value`
 ### Output Data Format
 
 Benchmark data saved to `warp-operation-yyyy-mm-dd[hhmmss]-xxxx.csv.zst`:
+
 - Zstandard compressed CSV
 - Can be analyzed with `warp analyze <file>`
 - Can be compared with `warp cmp <before> <after>`
@@ -172,6 +186,7 @@ Benchmark data saved to `warp-operation-yyyy-mm-dd[hhmmss]-xxxx.csv.zst`:
 ### Auto-termination
 
 When `--autoterm` enabled:
+
 - Continuously samples throughput into 25 time blocks
 - Checks if last 7 blocks are within `--autoterm.pct` threshold (default 7.5%)
 - Must maintain stability for `--autoterm.dur` (default 15s)
@@ -180,10 +195,13 @@ When `--autoterm` enabled:
 ## Common Issues
 
 ### 32-bit Architectures
+
 Be careful with 64-bit atomic operations - use `atomic.AddUint64` with proper alignment (see commit 042a9fc for context).
 
 ### TLS and Kernel TLS
+
 The project supports HTTP/2 and Kernel TLS (kTLS) for improved performance on Linux. See `cli/client_ktls.go` and `cli/client_transport.go`.
 
 ### InfluxDB Integration
+
 Real-time metrics can be pushed to InfluxDB v2+ using `--influxdb` flag. Connection string format: `<schema>://<token>@<hostname>:<port>/<bucket>/<org>?<tag=value>`

--- a/RDMA.md
+++ b/RDMA.md
@@ -28,11 +28,25 @@ cannot be cross-compiled.
 
 ### Package
 
+Every release artifact ships a `.sha256sum` beside it. Check it first:
+
+```bash
+λ sha256sum -c warp-rdma_<version>_amd64.deb.sha256sum
+warp-rdma_<version>_amd64.deb: OK
+```
+
+Then install:
+
 ```bash
 λ sudo dnf install warp-rdma-<version>-1.x86_64.rpm     # RHEL, Fedora, Rocky
 λ sudo apt install ./warp-rdma_<version>_amd64.deb      # Debian, Ubuntu
 λ sudo apk add --allow-untrusted warp-rdma_<version>_x86_64.apk
 ```
+
+apk needs `--allow-untrusted` because the package is not signed with a key in
+the host keyring. Verify the checksum above before using it. The published
+binaries also carry `.minisig` and `.asc` signatures if you want to check those
+against the MinIO release keys.
 
 The package installs `/usr/local/bin/warp` and the cuObj libraries it needs
 under `/usr/lib/warp`. It is a **drop-in replacement**: the command is `warp`,
@@ -52,8 +66,10 @@ Use it when you cannot install packages, or want several versions side by side.
 ### Host requirements
 
 The package bundles the cuObj libraries and links everything else statically, so
-the only things it needs from the host are:
+it needs only these from the host:
 
+- the base C and C++ runtime, `libc` and `libstdc++`, present on any
+  distribution
 - `libibverbs`, `librdmacm` and `libnuma`, declared as package dependencies
 - the vendor provider for your card, such as `libmlx5`, which must match the
   kernel driver and therefore cannot be bundled
@@ -188,6 +204,11 @@ newer, and the RDMA headers. On Debian or Ubuntu:
 λ sudo apt-get install g++ git libibverbs-dev librdmacm-dev libnuma-dev
 ```
 
+Distribution packages are often older than 3.31. `build-rdma.sh` checks the
+version and stops when it is too old, because vcpkg's port scripts need the
+newer one. Install a current CMake from
+[Kitware's apt repository](https://apt.kitware.com) or with `pip install cmake`.
+
 Then:
 
 ```bash
@@ -212,3 +233,16 @@ the same library list the release uses:
 libminiocpp is linked statically, so cgo, which links with `gcc` rather than
 `g++`, has to be told about the C++ runtime and every transitive archive by
 name. That list lives in `scripts/rdma-cgo-libs.txt`.
+
+The binary this produces still loads the cuObj libraries at run time, and
+nothing tells it where they are. Choose one:
+
+```bash
+λ sudo ldconfig                                  # if they are in a system path
+λ export LD_LIBRARY_PATH=/usr/local/lib          # per shell
+λ go build -tags=kqueue,rdma \
+    -ldflags "-extldflags=-Wl,-rpath,/usr/local/lib"   # baked into the binary
+```
+
+`build-rdma.sh` avoids the question by bundling the libraries in the archive and
+baking an `$ORIGIN/lib` rpath.

--- a/RDMA.md
+++ b/RDMA.md
@@ -1,0 +1,214 @@
+# S3 over RDMA
+
+The `--rdma` flag sends PUT and GET payloads over RDMA instead of HTTP. Warp
+gives each worker a registered buffer and lets the network card move object data
+straight into or out of it.
+
+| Value        | Buffer                   | Use it for                                        |
+| ------------ | ------------------------ | ------------------------------------------------- |
+| `--rdma=cpu` | Page-aligned host memory | RDMA between the server and host memory           |
+| `--rdma=gpu` | CUDA device memory       | GPU-Direct: the NIC transfers straight to the GPU |
+
+Leaving `--rdma` unset keeps the normal HTTP path. Only the `get` and `put`
+benchmarks accept `--rdma`; the others reject it rather than report HTTP numbers
+as if they were RDMA numbers.
+
+> [!IMPORTANT]
+> When an RDMA transfer cannot be set up, the underlying library falls back to
+> HTTP and the operation still succeeds. Warp cannot see that this happened, so
+> its output never tells you whether RDMA was used. Confirm that from the
+> storage server's S3 over RDMA counters before you trust a comparison.
+
+## Install
+
+RDMA support is compiled in, and the standard warp binaries are built without
+cgo, so they refuse `--rdma` at startup. Use one of the builds below instead.
+All of them are linux/amd64: the RDMA build links libminiocpp through cgo, so it
+cannot be cross-compiled.
+
+### Package
+
+```bash
+λ sudo dnf install warp-rdma-<version>-1.x86_64.rpm     # RHEL, Fedora, Rocky
+λ sudo apt install ./warp-rdma_<version>_amd64.deb      # Debian, Ubuntu
+λ sudo apk add --allow-untrusted warp-rdma_<version>_x86_64.apk
+```
+
+The package installs `/usr/local/bin/warp` and the cuObj libraries it needs
+under `/usr/lib/warp`. It is a **drop-in replacement**: the command is `warp`,
+the same as the standard package, so install one or the other rather than both.
+
+### Archive
+
+```bash
+λ tar xzf warp-rdma_linux_amd64.tar.gz
+λ ./warp-rdma/warp --version
+```
+
+The archive carries its libraries in a `lib` directory beside the binary and
+finds them on its own, so it needs no installation and no `LD_LIBRARY_PATH`.
+Use it when you cannot install packages, or want several versions side by side.
+
+### Host requirements
+
+The package bundles the cuObj libraries and links everything else statically, so
+the only things it needs from the host are:
+
+- `libibverbs`, `librdmacm` and `libnuma`, declared as package dependencies
+- the vendor provider for your card, such as `libmlx5`, which must match the
+  kernel driver and therefore cannot be bundled
+
+CUDA is **not** required to install or to run `--rdma=cpu`. The runtime is
+loaded on demand and only `--rdma=gpu` needs it.
+
+## Configure the client
+
+The cuObj client reads its settings from `cuobj.json`. Warp does not install
+this file, and without one that names your NIC, transfers fall back to HTTP
+instead of using RDMA.
+
+Point cuObj at a file with `CUFILE_ENV_PATH_JSON`:
+
+```bash
+λ export CUFILE_ENV_PATH_JSON=/etc/warp/cuobj.json
+```
+
+### Find your NIC address
+
+`rdma_dev_addr_list` takes the IPv4 address of the RDMA NIC to run over. Map the
+RDMA devices to interfaces, then read the address of the one on the same fabric
+as the storage server:
+
+```bash
+λ ibdev2netdev
+mlx5_0 port 1 ==> enp27s0np0 (Up)
+mlx5_1 port 1 ==> enp157s0np0 (Up)
+
+λ ip -4 -o addr show enp157s0np0
+enp157s0np0    inet 10.0.1.241/24 ...
+```
+
+### Write the file
+
+This is the shape a working client uses:
+
+```json
+{
+  "logging": { "level": "ERROR" },
+  "execution": { "parallel_io": false },
+  "properties": {
+    "allow_compat_mode": true,
+    "use_pci_p2pdma": true,
+    "rdma_peer_type": "dmabuf",
+    "rdma_dev_addr_list": ["10.0.1.241"],
+    "rdma_multipath_enabled": false
+  }
+}
+```
+
+| Setting                  | What it does                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `rdma_dev_addr_list`     | The NIC to run RDMA over. Required; without it transfers fall back to HTTP           |
+| `allow_compat_mode`      | Falls back to a compatible path when the `nvidia-fs` driver is absent                |
+| `use_pci_p2pdma`         | Lets the NIC move data across PCIe straight to the GPU, for `--rdma=gpu`             |
+| `rdma_peer_type`         | How GPU memory is registered with the NIC; `dmabuf` on current drivers               |
+| `rdma_multipath_enabled` | Failover across several NICs. Off when pinning one, which is what benchmark hosts do |
+| `logging.level`          | `NOTICE`, `ERROR`, `WARN`, `INFO`, `DEBUG` or `TRACE`                                |
+| `logging.dir`            | Where `cufile.log` is written; the current directory when unset                      |
+
+Two notes on the sample that ships with
+[minio-cpp](https://github.com/minio/minio-cpp/blob/main/vendor/cuobj/cuobj.json).
+Its `rdma_dev_addr_list` is a `<client-nic-ip>` placeholder, so copying it
+without editing leaves RDMA unconfigured. It also logs at `TRACE`, which is
+useful while bringing a host up and noisy afterwards; deployed clients run at
+`ERROR` or `INFO`.
+
+Multipath is worth enabling only when you list several NICs and want failover.
+The sample documents `rdma_max_backup_devices`, `rdma_io_retry_count`,
+`rdma_failback_enabled` and `rdma_health_check_interval_ms` for that case.
+
+## Run
+
+The storage server must have S3 over RDMA enabled and reachable from the client.
+
+```bash
+λ warp get --rdma=cpu --host=s3-server:9000 --access-key=minio --secret-key=minio123
+λ warp put --rdma=gpu --host=s3-server:9000 --access-key=minio --secret-key=minio123
+```
+
+`--rdma=gpu` additionally needs an NVIDIA GPU on the client, with a driver new
+enough for the installed CUDA runtime.
+
+Warp prints a warning at startup when it can tell that S3 over RDMA is not
+reachable. The probe is optimistic, so the absence of a warning is not proof
+that RDMA is working.
+
+`--rdma` works in [distributed mode](README.md#distributed-benchmarking) as
+well. The server passes the flag to every client, so each client needs an
+RDMA-capable warp binary and its own RDMA path to the storage server.
+
+## Troubleshooting
+
+**`--rdma=cpu requires the RDMA build of warp`**
+
+You are running a standard binary. Install one of the builds above.
+
+**`--rdma=gpu is unavailable: the oldest CUDA runtime on this host is X, but the
+NVIDIA driver only supports up to Y`**
+
+The CUDA runtime is newer than the driver can run. Upgrade the driver, or
+install a runtime the driver supports. A host can carry several runtimes; warp
+reports the closest one so the message names the smallest upgrade that helps.
+
+**`--rdma=gpu is unavailable: no usable CUDA runtime (libcudart) was found`**
+
+No CUDA runtime is installed. `--rdma=cpu` still works.
+
+**`error while loading shared libraries: libcuobjclient.so.1`**
+
+The binary cannot find the cuObj libraries. With the package they live in
+`/usr/lib/warp`; with the archive, run the binary from where you unpacked it so
+the bundled `lib` directory sits beside it.
+
+**Throughput looks like plain HTTP**
+
+RDMA failures fall back to HTTP silently, so warp's output looks normal. The
+usual cause is client configuration: no `cuobj.json`, or one whose
+`rdma_dev_addr_list` still holds the `<client-nic-ip>` placeholder. See
+[Configure the client](#configure-the-client). Raise `logging.level` to `DEBUG`
+to see what cuObj attempted, and confirm from the server's counters rather than
+from warp.
+
+## Build from source
+
+You need Go (the version in `go.mod`), git, a C++17 compiler, CMake 3.31 or
+newer, and the RDMA headers. On Debian or Ubuntu:
+
+```bash
+λ sudo apt-get install g++ git libibverbs-dev librdmacm-dev libnuma-dev
+```
+
+Then:
+
+```bash
+λ ./scripts/build-rdma.sh    # produces warp-rdma_linux_<arch>.tar.gz
+```
+
+The script builds [minio-cpp](https://github.com/minio/minio-cpp) with RDMA
+enabled, links warp against it statically, and packages the archive. It is also
+how the published archives are built, and it needs no CUDA package even though
+the result supports `--rdma=gpu`.
+
+To build the binary alone against an existing libminiocpp, pass its prefix and
+the same library list the release uses:
+
+```bash
+λ export CGO_ENABLED=1
+λ export CGO_CFLAGS="-I/usr/local/include"
+λ export CGO_LDFLAGS="-L/usr/local/lib $(cat scripts/rdma-cgo-libs.txt)"
+λ go build -tags=kqueue,rdma
+```
+
+libminiocpp is linked statically, so cgo, which links with `gcc` rather than
+`g++`, has to be told about the C++ runtime and every transitive archive by
+name. That list lives in `scripts/rdma-cgo-libs.txt`.

--- a/README.md
+++ b/README.md
@@ -5,47 +5,55 @@ S3 benchmarking tool.
 # Download
 
 ## From binary
+
 [Download Binary Releases](https://github.com/minio/warp/releases) for various platforms.
 
-To benchmark S3 over RDMA, download the separate `warp-rdma_linux_*.tar.gz` archive instead.
-See [S3 over RDMA](#s3-over-rdma).
+To benchmark S3 over RDMA, take the separate `warp-rdma` package or archive
+instead. See [RDMA.md](RDMA.md).
 
 ## Build with source
 
-Warp requires minimum Go `go1.21`, please ensure you have compatible version for this build. 
+Warp requires minimum Go `go1.21`, please ensure you have compatible version for this build.
 
 You can follow easy step below to build project
+
 - Clone project
+
 ```
 λ git clone https://github.com/minio/warp.git
 ```
+
 - Change directory and build
+
 ```
 λ cd warp && go build
 ```
+
 - To run a test, please run
+
 ```
 λ ./warp [options]
 ```
+
 # Configuration
 
-Warp can be configured either using commandline parameters or environment variables. 
-The S3 server to use can be specified on the commandline using `--host`, `--access-key`, 
+Warp can be configured either using commandline parameters or environment variables.
+The S3 server to use can be specified on the commandline using `--host`, `--access-key`,
 `--secret-key` and optionally `--tls` and `--region` to specify TLS and a custom region.
 
-It is also possible to set the same parameters using the `WARP_HOST`, `WARP_ACCESS_KEY`, 
+It is also possible to set the same parameters using the `WARP_HOST`, `WARP_ACCESS_KEY`,
 `WARP_SECRET_KEY`, `WARP_REGION` and `WARP_TLS` environment variables.
 
 The credentials must be able to create, delete and list buckets and upload files and perform the operation requested.
 
-By default operations are performed on a bucket called `warp-benchmark-bucket`. 
-This can be changed using the `--bucket` parameter. 
+By default operations are performed on a bucket called `warp-benchmark-bucket`.
+This can be changed using the `--bucket` parameter.
 
 > [!WARNING]
-> Note the bucket will be *completely wiped* before and after each run, so it should **not** contain any data.
+> Note the bucket will be _completely wiped_ before and after each run, so it should **not** contain any data.
 
-If you are [running TLS](https://docs.min.io/docs/how-to-secure-access-to-minio-server-with-tls.html), 
-you can enable [server-side-encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html) 
+If you are [running TLS](https://docs.min.io/docs/how-to-secure-access-to-minio-server-with-tls.html),
+you can enable [server-side-encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
 of objects using `--encrypt`. A random key will be generated and used for objects.
 To use [SSE-S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html) encryption use the `--sse-s3-encrypt` flag.
 
@@ -53,89 +61,26 @@ If your server is incompatible with [AWS v4 signatures](https://docs.aws.amazon.
 
 # S3 over RDMA
 
-The `--rdma` flag sends PUT and GET payloads over RDMA instead of HTTP.
-Each worker keeps one registered buffer, reused across operations and grown
-only when a larger object turns up, and the network card transfers object data
-directly into or out of it:
+The `--rdma` flag sends PUT and GET payloads over RDMA instead of HTTP, either
+into host memory (`--rdma=cpu`) or straight into GPU memory (`--rdma=gpu`).
 
-| Value        | Buffer                | Use it for                                      |
-|--------------|-----------------------|-------------------------------------------------|
-| `--rdma=cpu` | Page-aligned host memory | RDMA between the server and host memory      |
-| `--rdma=gpu` | CUDA device memory    | GPU-Direct: the NIC transfers straight to the GPU |
-
-Leaving `--rdma` unset keeps the normal HTTP path. Only the `get` and `put`
-benchmarks support `--rdma`; the other benchmarks reject it rather than report
-HTTP numbers as if they were RDMA numbers.
-
-> [!IMPORTANT]
-> When an RDMA transfer cannot be set up, the underlying library falls back to
-> HTTP and the operation still succeeds. Warp cannot see that this happened, so
-> its output never tells you whether RDMA was used. Confirm that from the
-> storage server's S3 over RDMA counters before you trust a comparison.
-
-## Getting a warp binary with RDMA support
-
-The standard release binaries are built without cgo, so RDMA dispatch is not
-compiled into them. Those binaries refuse `--rdma` at startup rather than
-failing on every operation. One extra archive is published per release and
-architecture, `warp-rdma_linux_amd64.tar.gz` and `warp-rdma_linux_arm64.tar.gz`.
-
-A single binary serves both modes. The CUDA runtime is loaded on demand rather
-than linked, so the archive runs on hosts with no CUDA installed at all; only
-`--rdma=gpu` needs it, and it says so plainly when it is missing.
-
-Each archive contains the `warp` binary and the libminiocpp and cuObj libraries
-in a `lib` directory next to it. Unpack the archive and run the binary from
-where you unpacked it; it finds those libraries on its own.
-
-The host must supply the rest of the RDMA stack itself: `libibverbs1`,
-`librdmacm1`, `libnuma1` and the vendor provider such as `libmlx5`. These are
-tied to the kernel driver, so bundling them would break more often than it
-would help. Install them if they are missing, or transfers fail or fall back to
-HTTP.
+Support is compiled in, so the standard binaries refuse `--rdma`. Install the
+`warp-rdma` package or archive from the release instead:
 
 ```bash
-λ tar xzf warp-rdma_linux_amd64.tar.gz
-λ ./warp-rdma/warp get --rdma=cpu --host=s3-server:9000 --access-key=minio --secret-key=minio123
+λ sudo apt install ./warp-rdma_<version>_amd64.deb   # or the rpm/apk
+λ warp get --rdma=cpu --host=s3-server:9000 --access-key=minio --secret-key=minio123
 ```
 
-To build one yourself you need Go (the version in `go.mod`), git, a C++17
-compiler, CMake 3.31 or newer, and the RDMA headers. On Debian or Ubuntu:
-
-```bash
-λ sudo apt-get install g++ git libibverbs-dev librdmacm-dev libnuma-dev
-```
-
-Then run:
-
-```bash
-λ ./scripts/build-rdma.sh    # produces warp-rdma_linux_<arch>.tar.gz
-```
-
-The script builds [minio-cpp](https://github.com/minio/minio-cpp) with RDMA
-enabled and links warp against it. It is also how the published archives are
-built. No CUDA package is needed to build, even for `--rdma=gpu` support.
-
-## Running the benchmark
-
-The storage server must have S3 over RDMA enabled and reachable from the
-client. `--rdma=gpu` additionally needs an NVIDIA GPU with its driver and CUDA
-runtime installed on the client.
-
-Warp prints a warning at startup when it can tell that S3 over RDMA is not
-reachable. The probe is optimistic, so the absence of a warning is not proof
-that RDMA is working.
-
-`--rdma` works in [distributed mode](#distributed-benchmarking) as well. The
-server passes the flag to every client, so each client needs an RDMA-capable
-warp binary and its own RDMA path to the storage server.
+See [RDMA.md](RDMA.md) for installation, host requirements, troubleshooting and
+how to build it yourself.
 
 # Usage
 
 `λ warp command [options]`
 
-Example running a mixed type benchmark against 8 servers named `s3-server-1` to `s3-server-8` 
-on port 9000 with the provided keys: 
+Example running a mixed type benchmark against 8 servers named `s3-server-1` to `s3-server-8`
+on port 9000 with the provided keys:
 
 `λ warp mixed --host=s3-server{1...8}:9000 --access-key=minio --secret-key=minio123 --autoterm`
 
@@ -150,8 +95,8 @@ configuration files for each benchmark type.
 
 To run a benchmark use `λ warp run <file.yml>`.
 
-Values can be injected from the commandline using one or multiple `-var VarName=Value`. 
-These values can be referenced inside YAML files with `{{.VarName}}`. 
+Values can be injected from the commandline using one or multiple `-var VarName=Value`.
+These values can be referenced inside YAML files with `{{.VarName}}`.
 Go [text templates](https://pkg.go.dev/text/template) are used for this.
 
 # Benchmarks
@@ -164,6 +109,7 @@ This can however also be tweaked using the `--concurrent` parameter.
 Warp includes benchmarks for Apache Iceberg REST catalog operations. These test catalog metadata performance including namespace, table, and view operations.
 
 Available commands:
+
 - `warp iceberg catalog-read` - Catalog read operations
 - `warp iceberg catalog-commits` - Commit generation via property updates
 - `warp iceberg catalog-mixed` - Mixed read/write workload
@@ -173,31 +119,31 @@ Supports MinIO AIStor Tables and Apache Polaris catalogs.
 
 See [README_TABLES.md](README_TABLES.md) for detailed documentation.
 
-Tweaking concurrency can have an impact on performance, especially if latency to the server is tested. 
+Tweaking concurrency can have an impact on performance, especially if latency to the server is tested.
 Most benchmarks will also use different prefixes for each "thread" running.
 
-By default all benchmarks save all request details to a file named `warp-operation-yyyy-mm-dd[hhmmss]-xxxx.csv.zst`. 
-A custom file name can be specified using the `--benchdata` parameter. 
+By default all benchmarks save all request details to a file named `warp-operation-yyyy-mm-dd[hhmmss]-xxxx.csv.zst`.
+A custom file name can be specified using the `--benchdata` parameter.
 The raw data is [zstandard](https://facebook.github.io/zstd/) compressed CSV data.
 
 ## Multiple Hosts
 
-Multiple S3 hosts can be specified as comma-separated values, for instance 
+Multiple S3 hosts can be specified as comma-separated values, for instance
 `--host=10.0.0.1:9000,10.0.0.2:9000` will switch between the specified servers.
 
-Alternatively numerical ranges can be specified using `--host=10.0.0.{1...10}:9000` which will add 
+Alternatively numerical ranges can be specified using `--host=10.0.0.{1...10}:9000` which will add
 `10.0.0.1` through `10.0.0.10`. This syntax can be used for any part of the host name and port.
 
 A file with newline separated hosts can also be specified using `file:` prefix and a file name.
 For distributed tests the file will be read locally and sent to each client.
 
-By default a host is chosen between the hosts that have the least number of requests running 
-and with the longest time since the last request finished. This will ensure that in cases where 
-hosts operate at different speeds that the fastest servers will get the most requests. 
-It is possible to choose a simple round-robin algorithm by using the `--host-select=roundrobin` parameter. 
+By default a host is chosen between the hosts that have the least number of requests running
+and with the longest time since the last request finished. This will ensure that in cases where
+hosts operate at different speeds that the fastest servers will get the most requests.
+It is possible to choose a simple round-robin algorithm by using the `--host-select=roundrobin` parameter.
 If there is only one host this parameter has no effect.
 
-When benchmarks are done per host averages will be printed out. 
+When benchmarks are done per host averages will be printed out.
 For further details, the `--analyze.v` parameter can also be used.
 
 # Distributed Benchmarking
@@ -243,7 +189,7 @@ The server will coordinate the benchmark runs and make sure they are run correct
 When the benchmark has finished, the combined benchmark info will be collected, merged and saved/displayed.
 Each client will also save its own data locally.
 
-Enabling server mode is done by adding `--warp-client=client-{1...10}:7761` 
+Enabling server mode is done by adding `--warp-client=client-{1...10}:7761`
 or a comma separated list of warp client hosts.
 Finally, a file with newline separated hosts can also be specified using `file:` prefix and a file name.
 If no host port is specified the default is added.
@@ -254,8 +200,8 @@ Example:
 λ warp get --duration=3m --warp-client=client-{1...10} --host=minio-server-{1...16} --access-key=minio --secret-key=minio123
 ```
 
-Note that parameters apply to *each* client. 
-So if `--concurrent=8` is specified each client will run with 8 concurrent operations. 
+Note that parameters apply to _each_ client.
+So if `--concurrent=8` is specified each client will run with 8 concurrent operations.
 If a warp server is unable to connect to a client the entire benchmark is aborted.
 
 If the warp server looses connection to a client during a benchmark run an error will
@@ -309,19 +255,19 @@ configured correctly (one route per subnet via the corresponding NIC).
 ### Manually Distributed Benchmarking
 
 While it is highly recommended to use the automatic distributed benchmarking warp can also
-be run manually on several machines at once. 
+be run manually on several machines at once.
 
-When running benchmarks on several clients, it is possible to synchronize 
-their start time using the `--syncstart` parameter. 
-The time format is 'hh:mm' where hours are specified in 24h format, 
-and parsed as local computer time. 
+When running benchmarks on several clients, it is possible to synchronize
+their start time using the `--syncstart` parameter.
+The time format is 'hh:mm' where hours are specified in 24h format,
+and parsed as local computer time.
 
 Using this will make it more reliable to [merge benchmarks](https://github.com/minio/warp#merging-benchmarks)
 from the clients for total result.
-This will combine the data as if it was run on the same client. 
-Only the time segments that was actually overlapping will be considered. 
+This will combine the data as if it was run on the same client.
+Only the time segments that was actually overlapping will be considered.
 
-When running benchmarks on several clients it is likely a good idea to specify the `--noclear` parameter 
+When running benchmarks on several clients it is likely a good idea to specify the `--noclear` parameter
 so clients don't accidentally delete each others data on startup.
 
 ## Benchmark Data
@@ -338,7 +284,7 @@ Different benchmark types will have different default values.
 
 #### Random File Sizes
 
-It is possible to randomize object sizes by specifying  `--obj.randsize` 
+It is possible to randomize object sizes by specifying `--obj.randsize`
 and files will have a "random" size up to `--obj.size`.
 However, there are some things to consider "under the hood".
 
@@ -380,9 +326,9 @@ Throughput, split into 29 x 1s:
  * Slowest: 4287.0MiB/s, 2399.84 obj/s (1s, starting 19:03:53 CEST)
 ```
 
-The average object size will be close to `--obj.size` multiplied by 0.179151. 
+The average object size will be close to `--obj.size` multiplied by 0.179151.
 
-To get a value for `--obj.size` multiply the desired average object size by 5.582 to get a maximum value. 
+To get a value for `--obj.size` multiply the desired average object size by 5.582 to get a maximum value.
 
 #### Bucketed File Size
 
@@ -397,49 +343,50 @@ E.g.: the value `4096:10740,8192:1685,16384:1623` will trigger objects whose siz
 between 0 and 4096 with a weight of 10740, between 4096 and 8192 with a weight of 1685,
 or between 8192 and 16384 with a weight of 1623.
 
-
 ## Automatic Termination
-Adding `--autoterm` parameter will enable automatic termination when results are considered stable. 
-To detect a stable setup, warp continuously downsample the current data to 
+
+Adding `--autoterm` parameter will enable automatic termination when results are considered stable.
+To detect a stable setup, warp continuously downsample the current data to
 25 data points stretched over the current timeframe.
 
-For a benchmark to be considered "stable", the last 7 of 25 data points must be within a specified percentage. 
+For a benchmark to be considered "stable", the last 7 of 25 data points must be within a specified percentage.
 Looking at the throughput over time, it could look like this:
 
 ![stable](https://user-images.githubusercontent.com/5663952/72053512-0df95900-327c-11ea-8bc5-9b4064fa595f.png)
 
-The red frame shows the window used to evaluate stability. 
-The height of the box is determined by the threshold percentage of the current speed. 
-This percentage is user configurable through `--autoterm.pct`, default 7.5%. 
+The red frame shows the window used to evaluate stability.
+The height of the box is determined by the threshold percentage of the current speed.
+This percentage is user configurable through `--autoterm.pct`, default 7.5%.
 The metric used for this is either MiB/s or obj/s depending on the benchmark type.
 
-To make sure there is a good sample data, a minimum duration of the 7 of 25 samples is set. 
+To make sure there is a good sample data, a minimum duration of the 7 of 25 samples is set.
 This is configurable `--autoterm.dur`. This specifies the minimum time length the benchmark must have been stable.
 
-If the benchmark doesn't autoterminate it will continue until the duration is reached. 
+If the benchmark doesn't autoterminate it will continue until the duration is reached.
 This cannot be used when benchmarks are running remotely.
 
-A permanent 'drift' in throughput will prevent automatic termination, 
+A permanent 'drift' in throughput will prevent automatic termination,
 if the drift is more than the specified percentage.
 This is by design since this should be recorded.
 
-When using automatic termination be aware that you should not compare average speeds, 
-since the length of the benchmark runs will likely be different. 
+When using automatic termination be aware that you should not compare average speeds,
+since the length of the benchmark runs will likely be different.
 Instead 50% medians are a much better metrics.
 
 ## Mixed
 
-Mixed mode benchmark will test several operation types at once. 
-The benchmark will upload `--objects` objects of size `--obj.size` and use these objects as a pool for the benchmark. 
+Mixed mode benchmark will test several operation types at once.
+The benchmark will upload `--objects` objects of size `--obj.size` and use these objects as a pool for the benchmark.
 As new objects are uploaded/deleted they are added/removed from the pool.
 
 The distribution of operations can be adjusted with the `--get-distrib`, `--stat-distrib`,
- `--put-distrib` and `--delete-distrib` parameters.  
- The final distribution will be determined by the fraction of each value of the total. 
- Note that `put-distrib` must be bigger or equal to `--delete-distrib` to not eventually run out of objects.  
+`--put-distrib` and `--delete-distrib` parameters.  
+ The final distribution will be determined by the fraction of each value of the total.
+Note that `put-distrib` must be bigger or equal to `--delete-distrib` to not eventually run out of objects.  
  To disable a type, set its distribution to 0.
 
 Example:
+
 ```
 λ warp mixed --duration=1m
 [...]
@@ -458,10 +405,10 @@ Operation: DELETE
  * 78.91 obj/s (59.927s, starting 07:44:05 PST) (10.0% of operations)
 ```
 
-
 A similar benchmark is called `versioned` which operates on versioned objects.
 
 ## GET
+
 Benchmarking get operations will attempt to download as many objects it can within `--duration`.
 
 By default, `--objects` objects of size `--obj.size` are uploaded before doing the actual bench.
@@ -495,7 +442,7 @@ These can be accessed using the `--analyze.v` parameter.
 
 It is possible to test speed of partial file requests using the `--range` option.
 This will start reading each object at a random offset and read a random number of bytes.
-Using this produces output similar to `--obj.randsize` - and they can even be combined. 
+Using this produces output similar to `--obj.randsize` - and they can even be combined.
 
 ## PUT
 
@@ -513,7 +460,7 @@ Throughput, split into 59 x 1s:
  * Slowest: 6.7MiB/s, 685.26 obj/s
 ```
 
-It is possible by forcing md5 checksums on data by using the `--md5` option. 
+It is possible by forcing md5 checksums on data by using the `--md5` option.
 
 To test [POST Object](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html) operations use `-post` parameter.
 
@@ -549,13 +496,13 @@ Throughput, split into 59 x 1s:
 
 ## LIST
 
-Benchmarking list operations will upload `--objects` objects of size `--obj.size` with `--concurrent` prefixes. 
+Benchmarking list operations will upload `--objects` objects of size `--obj.size` with `--concurrent` prefixes.
 The list operations are done per prefix.
 
-If versioned listing should be tested, it is possible by setting `--versions=N` (default 1), 
+If versioned listing should be tested, it is possible by setting `--versions=N` (default 1),
 which will add multiple versions of each object and use `ListObjectVersions` for listing.
 
-The analysis will include the upload stats as `PUT` operations and the `LIST` operations separately. 
+The analysis will include the upload stats as `PUT` operations and the `LIST` operations separately.
 The time from request start to first object is recorded as well and can be accessed using the `--analyze.v` parameter.
 
 ```
@@ -570,7 +517,7 @@ Throughput, split into 59 x 1s:
 
 ## STAT
 
-Benchmarking [stat object](https://docs.min.io/docs/golang-client-api-reference#StatObject) operations 
+Benchmarking [stat object](https://docs.min.io/docs/golang-client-api-reference#StatObject) operations
 will upload `--objects` objects of size `--obj.size` with `--concurrent` prefixes.
 
 If versioned listing should be tested, it is possible by setting `--versions=n` (default 1),
@@ -581,6 +528,7 @@ The main benchmark will do individual requests to get object information for the
 Since the object size is of little importance, only objects per second is reported.
 
 Example:
+
 ```
 λ warp stat --autoterm
 [...]
@@ -600,6 +548,7 @@ Benchmarking [PutObjectRetention](https://docs.aws.amazon.com/AmazonS3/latest/AP
 will upload `--objects` objects of size `--obj.size` with `--concurrent` prefixes and `--versions` versions on each object.
 
 Example:
+
 ```
 λ warp retention --objects=2500 --duration=1m
 [...]
@@ -617,17 +566,17 @@ Throughput, split into 59 x 1s:
  * Slowest: 161.73 obj/s
 ```
 
-Note that since object locking can only be specified when creating a bucket, it may be needed to recreate the bucket. 
+Note that since object locking can only be specified when creating a bucket, it may be needed to recreate the bucket.
 Warp will attempt to do that automatically.
 
 ## MULTIPART
 
-Multipart benchmark will upload parts to a *single* object, and afterwards test download speed of parts.
+Multipart benchmark will upload parts to a _single_ object, and afterwards test download speed of parts.
 
 When running in distributed mode each client will upload the number of parts specified.
 
-Only `--concurrent` uploads will be started by each client, 
-so having `--parts` be a multiple of `--concurrent` is recommended, but not required. 
+Only `--concurrent` uploads will be started by each client,
+so having `--parts` be a multiple of `--concurrent` is recommended, but not required.
 
 ```
 λ warp multipart --parts=500 --part.size=10MiB
@@ -667,14 +616,14 @@ multiplied by `--part.concurrent`.
 ╭─────────────────────────────────╮
 │ WARP S3 Benchmark Tool by MinIO │
 ╰─────────────────────────────────╯
-                                                                       
+
 Benchmarking: Press 'q' to abort benchmark and print partial results...
-                                                                       
+
  λ █████████████████████████████████████████████████████████████████████████ 100%
-                                                                                       
-Reqs: 15867, Errs:0, Objs:15867, Bytes: 1983.4MiB                                      
+
+Reqs: 15867, Errs:0, Objs:15867, Bytes: 1983.4MiB
  -   PUTPART Average: 266 Obj/s, 33.2MiB/s; Current 260 Obj/s, 32.5MiB/s, 1193.7 ms/req
-                                                                                       
+
 Report: PUTPART. Concurrency: 400. Ran: 58s
  * Average: 33.36 MiB/s, 266.85 obj/s
  * Reqs: Avg: 1262.5ms, 50%: 935.3ms, 90%: 2773.8ms, 99%: 4395.2ms, Fastest: 53.6ms, Slowest: 6976.4ms, StdDev: 1027.5ms
@@ -693,7 +642,7 @@ Cleanup Done
 Benchmarks S3 Express One Zone [Append Object](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-objects-append.html) operations.
 
 WARP will upload `--obj.size` objects for each `--concurrent` and append up to 10,000 parts to these.
-Each append operation will be one part and the size of each part will be `--part.size` - a new object will be created when the part limit is reached. 
+Each append operation will be one part and the size of each part will be `--part.size` - a new object will be created when the part limit is reached.
 
 If no `--checksum` is specified, the CRC64NVME checksum will be used. The checksum type must support full object checksums (CRC32, CRC32C, CRC64NVME).
 
@@ -728,13 +677,14 @@ The "obj/s" indicates the number of append operations per second.
 ## ZIP
 
 The `zip` command benchmarks the MinIO [s3zip](https://blog.min.io/small-file-archives/) extension
-that allows 
+that allows
 
 This will upload a single zip file with 10000 individual files (change with `--files`) of 10KiB each (changed with `--obj.size`).
 
 The benchmark will then download individual files concurrently and present the result as a GET benchmark.
 
 Example:
+
 ```
 λ warp zip --obj.size=1MiB -duration=1m
 warp: Benchmark data written to "warp-zip-2022-12-02[150109]-xmXj.csv.zst"
@@ -757,18 +707,19 @@ The Snowball benchmark will test uploading a "snowball" TAR file with multiple f
 
 Parameters:
 
-* `--obj.size=N` controls the size of each object inside the TAR file that is uploaded. Default is 512KiB.
-* `--objs.per=N` controls the number of objects per TAR file. Default is 50.
-* `--compress` will compress the TAR file before upload. Object data will be duplicated inside each TAR. This limits `--obj.size` to 10MiB.
+- `--obj.size=N` controls the size of each object inside the TAR file that is uploaded. Default is 512KiB.
+- `--objs.per=N` controls the number of objects per TAR file. Default is 50.
+- `--compress` will compress the TAR file before upload. Object data will be duplicated inside each TAR. This limits `--obj.size` to 10MiB.
 
 Since TAR operations are done in-memory the total size is limited to 1GiB.
 
-This is calculated as `--obj.size` * `--concurrent`. 
-If `--compress` is NOT specified this is also multiplied by `--objs.per`. 
+This is calculated as `--obj.size` \* `--concurrent`.
+If `--compress` is NOT specified this is also multiplied by `--objs.per`.
 
 Examples:
 
 Benchmark using default parameters. 50 x 512KiB duplicated objects inside each TAR file. Compressed.
+
 ```
 λ warp snowball --duration=30s --compress
 warp: Benchmark data written to "warp-snowball-2023-04-06[115116]-9S9Z.csv.zst"
@@ -785,6 +736,7 @@ warp: Cleanup Done.
 ```
 
 Test 1000 unique 1KB objects inside each snowball, with 2 concurrent uploads running:
+
 ```
 λ warp snowball --duration=60s --obj.size=1K --objs.per=1000 --concurrent=2
 warp: Benchmark data written to "warp-snowball-2023-04-06[114915]-W3zw.csv.zst"
@@ -811,12 +763,12 @@ This feature is only available on a recent MinIO server.
 
 Parameters:
 
-* `--obj.size=N` controls the size of each object that is uploaded. Default is 1MiB.
-* `--copies=N` controls the number of object copies per request. Default is 100.
+- `--obj.size=N` controls the size of each object that is uploaded. Default is 1MiB.
+- `--copies=N` controls the number of object copies per request. Default is 100.
 
-Size is calculated as `--obj.size` * `--copies`.
+Size is calculated as `--obj.size` \* `--copies`.
 
-Example: Use 8 concurrent uploads to copy a 512KB objects to 50 locations. 
+Example: Use 8 concurrent uploads to copy a 512KB objects to 50 locations.
 
 ```
 λ warp fanout --copies=50 --obj.size=512KiB --concurrent=8
@@ -837,7 +789,6 @@ The analysis throughput represents the object count and sizes as they are writte
 
 Request times shown with `--analyze.v` represents request time for each fan-out call.
 
-
 # Analysis
 
 When benchmarks have finished all request data will be saved to a file and an analysis will be shown.
@@ -846,23 +797,25 @@ The saved data can be re-evaluated by running `warp analyze (filename)`.
 
 ## Analysis Data
 
-All analysis will be done on a reduced part of the full data. 
-The data aggregation will *start* when all threads have completed one request
- and the time segment will *stop* when the last request of a thread is initiated.
+All analysis will be done on a reduced part of the full data.
+The data aggregation will _start_ when all threads have completed one request
+and the time segment will _stop_ when the last request of a thread is initiated.
 
 This is to exclude variations due to warm-up and threads finishing at different times.
 Therefore the analysis time will typically be slightly below the selected benchmark duration.
 
 Example:
+
 ```
 Operation: GET
 * Average: 92.05 MiB/s, 9652.01 obj/s
 ```
 
-The benchmark run is then divided into fixed duration *segments* specified by `-analyze.dur`. 
+The benchmark run is then divided into fixed duration _segments_ specified by `-analyze.dur`.
 For each segment the throughput is calculated across all threads.
 
 The analysis output will display the fastest, slowest and 50% median segment.
+
 ```
 Throughput, split into 59 x 1s:
  * Fastest: 97.9MiB/s, 10269.68 obj/s
@@ -872,10 +825,10 @@ Throughput, split into 59 x 1s:
 
 ### Analysis Parameters
 
-Beside the important `--analyze.dur` which specifies the time segment size for 
+Beside the important `--analyze.dur` which specifies the time segment size for
 aggregated data there are some additional parameters that can be used.
 
-Specifying `--analyze.v` will output time aggregated data per host instead of just averages. 
+Specifying `--analyze.v` will output time aggregated data per host instead of just averages.
 For instance:
 
 ```
@@ -889,7 +842,6 @@ Throughput by host:
         - 50% Median: 82.28 MiB/s, 82.28 obj/s (1s)
         - Slowest: 68.40 MiB/s, 68.40 obj/s (1s)
 ```
-
 
 `--analyze.op=GET` will only analyze GET operations.
 
@@ -951,48 +903,48 @@ Throughput, split into 59 x 1s:
  * Slowest: 1430.5KiB/s, 5721.95 obj/s (1s, starting 12:31:59 CET)
 ```
 
-* `TTFB` for downloads is the time from the request was sent until the first byte of the response was received.
-* `TTFB` for uploads is the time from the last byte of the request body was sent until the response was received.
-* `First Access` is the first access per object.
-* `Last Access` is the last access per object.
+- `TTFB` for downloads is the time from the request was sent until the first byte of the response was received.
+- `TTFB` for uploads is the time from the last byte of the request body was sent until the response was received.
+- `First Access` is the first access per object.
+- `Last Access` is the last access per object.
 
-The fastest and slowest request times are shown, as well as selected 
+The fastest and slowest request times are shown, as well as selected
 percentiles and the total amount is requests considered.
 
-Note that different metrics are used to select the number of requests per host and for the combined, 
+Note that different metrics are used to select the number of requests per host and for the combined,
 so there will likely be differences.
 
 ### Time Series CSV Output
 
-It is possible to output the CSV data of analysis using `--analyze.out=filename.csv` 
+It is possible to output the CSV data of analysis using `--analyze.out=filename.csv`
 which will write the CSV data to the specified file.
 
 These are the data fields exported:
 
 | Header              | Description                                                                                       |
-|---------------------|---------------------------------------------------------------------------------------------------|
+| ------------------- | ------------------------------------------------------------------------------------------------- |
 | `index`             | Index of the segment                                                                              |
 | `op`                | Operation executed                                                                                |
 | `host`              | If only one host, host name, otherwise empty                                                      |
 | `duration_s`        | Duration of the segment in seconds                                                                |
 | `objects_per_op`    | Objects per operation                                                                             |
-| `bytes`             | Total bytes of operations (*distributed*)                                                         |
+| `bytes`             | Total bytes of operations (_distributed_)                                                         |
 | `full_ops`          | Operations completely contained within segment                                                    |
 | `partial_ops`       | Operations that either started or ended outside the segment, but was also executed during segment |
 | `ops_started`       | Operations started within segment                                                                 |
 | `ops_ended`         | Operations ended within the segment                                                               |
 | `errors`            | Errors logged on operations ending within the segment                                             |
-| `mb_per_sec`        | MiB/s of operations within the segment (*distributed*)                                            |
+| `mb_per_sec`        | MiB/s of operations within the segment (_distributed_)                                            |
 | `ops_ended_per_sec` | Operations that ended within the segment per second                                               |
-| `objs_per_sec`      | Objects per second processed in the segment (*distributed*)                                       |
+| `objs_per_sec`      | Objects per second processed in the segment (_distributed_)                                       |
 | `start_time`        | Absolute start time of the segment                                                                |
 | `end_time`          | Absolute end time of the segment                                                                  |
 
-Some of these fields are *distributed*. 
-This means that the data of partial operations have been distributed across the segments they occur in. 
+Some of these fields are _distributed_.
+This means that the data of partial operations have been distributed across the segments they occur in.
 The bigger a percentage of the operation is within a segment the larger part of it has been attributed there.
 
-This is why there can be a partial object attributed to a segment, 
+This is why there can be a partial object attributed to a segment,
 because only a part of the operation took place in the segment.
 
 ## Comparing Benchmarks
@@ -1003,6 +955,7 @@ There is no need for 'before' to be chronologically before 'after', but the diff
 as change from 'before' to 'after'.
 
 An example:
+
 ```
 λ warp cmp warp-get-2019-11-29[125341]-7ylR.csv.zst warp-get-2019-202011-29[124533]-HOhm.csv.zst
 -------------------
@@ -1039,14 +992,13 @@ The main reason for running the benchmark on several clients would be to help el
 
 It is important to note that only data that strictly overlaps in absolute time will be considered for analysis.
 
-
 ## InfluxDB Output
 
 Warp allows realtime statistics to be pushed to InfluxDB v2 or later.
 
 This can be combined with the `--stress` parameter, which will allow to have long-running tests without consuming memory and still get access to performance numbers.
 
-Warp does not provide any analysis on the data sent to InfluxDB. 
+Warp does not provide any analysis on the data sent to InfluxDB.
 
 ### Configuring
 
@@ -1055,7 +1007,7 @@ InfluxDB is enabled via a the `--influxdb` parameter. Alternatively the paramete
 The value must be formatted like a URL: `<schema>://<token>@<hostname>:<port>/<bucket>/<org>?<tag=value>`
 
 | Part          |                                                                               |
-|---------------|-------------------------------------------------------------------------------|
+| ------------- | ----------------------------------------------------------------------------- |
 | `<schema>`    | Connection type. Replace with `http` or `https`                               |
 | `<token>`     | Replace with the token needed to access the server                            |
 | `<hostname>`  | Replace with the host name or IP address of your server                       |
@@ -1081,35 +1033,34 @@ For distributed benchmarking all clients will be sending data, so hosts like loc
 All in-run measurements are of type `warp`.
 
 | Tag        | Value                                                                                                                                                         |
-|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `warp_id`  | Contains a random string value, unique per client.<br/>This can be used to identify individual runs or single warp clients when using distributed benchmarks. |
 | `op`       | Contains the operation type, for example GET, PUT, DELETE, etc.                                                                                               |
 | `endpoint` | Endpoint is the endpoint to which the operation was sent.<br/>Measurements without this value is total for the warp client.                                   |
 
-
 Fields are sent as accumulated totals per run per operation type.
 
 New metrics are sent as each operation (request) completes. There is no inter-operation progress logged.
-This means that bigger objects (meaning less requests) will create bigger fluctuations. That is important to note when analyzing. 
+This means that bigger objects (meaning less requests) will create bigger fluctuations. That is important to note when analyzing.
 
-| Field                     | Value                                                                          |
-|---------------------------|--------------------------------------------------------------------------------|
-| `requests`                | Total number of requests performed                                             |
-| `objects`                 | Total number of objects affected                                               |
-| `bytes_total`             | Total number of bytes affected                                                 |
-| `errors`                  | Total errors encountered                                                       |
-| `request_total_secs`      | Total request time in seconds                                                  |
-| `request_ttfb_total_secs` | Total time to first byte in seconds for relevant operations                    |
+| Field                     | Value                                                       |
+| ------------------------- | ----------------------------------------------------------- |
+| `requests`                | Total number of requests performed                          |
+| `objects`                 | Total number of objects affected                            |
+| `bytes_total`             | Total number of bytes affected                              |
+| `errors`                  | Total errors encountered                                    |
+| `request_total_secs`      | Total request time in seconds                               |
+| `request_ttfb_total_secs` | Total time to first byte in seconds for relevant operations |
 
-The statistics provided means that to get "rates over time" the numbers must be calculated as differences (increase/positive derivatives). 
+The statistics provided means that to get "rates over time" the numbers must be calculated as differences (increase/positive derivatives).
 
 ### Summary
 
-When a run has finished a summary will be sent. This will be a `warp_run_summary` measurement type. 
+When a run has finished a summary will be sent. This will be a `warp_run_summary` measurement type.
 In addition to the fields above it will contain:
 
 | Field                   | Value                             |
-|-------------------------|-----------------------------------|
+| ----------------------- | --------------------------------- |
 | `request_avg_secs`      | Average Request Time              |
 | `request_max_secs`      | Longest Request Time              |
 | `request_min_secs`      | Shortest Request Time             |
@@ -1119,26 +1070,26 @@ In addition to the fields above it will contain:
 
 All times are in float point seconds.
 
-The summary will be sent for each host and operation type. 
+The summary will be sent for each host and operation type.
 
 # Server Profiling
 
 When running against a MinIO server it is possible to enable profiling while the benchmark is running.
 
-This is done by adding `--serverprof=type` parameter with the type of profile you would like. 
+This is done by adding `--serverprof=type` parameter with the type of profile you would like.
 This requires that the credentials allows admin access for the first host.
 
 | Type    | Description                                                                                                                                |
-|---------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `cpu`   | CPU profile determines where a program spends its time while actively consuming CPU cycles (as opposed while sleeping or waiting for I/O). |
 | `mem`   | Heap profile reports the currently live allocations; used to monitor current memory usage or check for memory leaks.                       |
 | `block` | Block profile show where goroutines block waiting on synchronization primitives (including timer channels).                                |
 | `mutex` | Mutex profile reports the lock contentions. When you think your CPU is not fully utilized due to a mutex contention, use this profile.     |
 | `trace` | A detailed trace of execution of the current program. This will include information about goroutine scheduling and garbage collection.     |
 
-Profiles for all cluster members will be downloaded as a zip file. 
+Profiles for all cluster members will be downloaded as a zip file.
 
-Analyzing the profiles requires the Go tools to be installed. 
-See [Profiling Go Programs](https://blog.golang.org/profiling-go-programs) for basic usage of the profile tools 
-and an introduction to the [Go execution tracer](https://blog.gopheracademy.com/advent-2017/go-execution-tracer/) 
+Analyzing the profiles requires the Go tools to be installed.
+See [Profiling Go Programs](https://blog.golang.org/profiling-go-programs) for basic usage of the profile tools
+and an introduction to the [Go execution tracer](https://blog.gopheracademy.com/advent-2017/go-execution-tracer/)
 for more information.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ If your server is incompatible with [AWS v4 signatures](https://docs.aws.amazon.
 
 # S3 over RDMA
 
-The `--rdma` flag sends PUT and GET payloads over RDMA instead of HTTP, either
-into host memory (`--rdma=cpu`) or straight into GPU memory (`--rdma=gpu`).
+The `--rdma` flag attempts to send PUT and GET payloads over RDMA rather than
+HTTP, either into host memory (`--rdma=cpu`) or straight into GPU memory
+(`--rdma=gpu`). It falls back to HTTP when RDMA cannot be set up.
 
 Support is compiled in, so the standard binaries refuse `--rdma`. Install the
 `warp-rdma` package or archive from the release instead:
@@ -677,7 +678,8 @@ The "obj/s" indicates the number of append operations per second.
 ## ZIP
 
 The `zip` command benchmarks the MinIO [s3zip](https://blog.min.io/small-file-archives/) extension
-that allows
+which serves individual files from inside a zip archive without unpacking it
+first.
 
 This will upload a single zip file with 10000 individual files (change with `--files`) of 10KiB each (changed with `--obj.size`).
 
@@ -811,7 +813,7 @@ Operation: GET
 * Average: 92.05 MiB/s, 9652.01 obj/s
 ```
 
-The benchmark run is then divided into fixed duration _segments_ specified by `-analyze.dur`.
+The benchmark run is then divided into fixed duration _segments_ specified by `--analyze.dur`.
 For each segment the throughput is calculated across all threads.
 
 The analysis output will display the fastest, slowest and 50% median segment.

--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ Operation: GET
 * Average: 92.05 MiB/s, 9652.01 obj/s
 ```
 
-The benchmark run is then divided into fixed duration _segments_ specified by `--analyze.dur`.
+The benchmark run is then divided into fixed-duration _segments_ specified by `--analyze.dur`.
 For each segment the throughput is calculated across all threads.
 
 The analysis output will display the fastest, slowest and 50% median segment.

--- a/README_ICEBERG.md
+++ b/README_ICEBERG.md
@@ -8,12 +8,12 @@ Warp provides benchmarking tools for Apache Iceberg REST catalog operations. The
 
 Four benchmark commands are available:
 
-| Command | Description |
-|---------|-------------|
-| `warp iceberg catalog-read` | Catalog read operations (list, get, exists) |
-| `warp iceberg catalog-commits` | Table/view property updates (commit generation) |
-| `warp iceberg catalog-mixed` | Mixed read/write workload |
-| `warp iceberg sustained` | Sustained workload with controlled RPS (commits + reads) |
+| Command                        | Description                                              |
+| ------------------------------ | -------------------------------------------------------- |
+| `warp iceberg catalog-read`    | Catalog read operations (list, get, exists)              |
+| `warp iceberg catalog-commits` | Table/view property updates (commit generation)          |
+| `warp iceberg catalog-mixed`   | Mixed read/write workload                                |
+| `warp iceberg sustained`       | Sustained workload with controlled RPS (commits + reads) |
 
 ## Supported Catalogs
 
@@ -25,47 +25,52 @@ Four benchmark commands are available:
 All iceberg commands share these flags:
 
 ### Connection
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--host` | (required) | Catalog server host(s), comma-separated or expandable patterns |
-| `--access-key` | (required) | Access key (AWS key or OAuth client ID) |
-| `--secret-key` | (required) | Secret key (AWS secret or OAuth client secret) |
-| `--region` | us-east-1 | AWS region |
-| `--tls` | false | Use TLS |
-| `--external-catalog` | "" | External catalog type (`polaris`) |
+
+| Flag                 | Default    | Description                                                    |
+| -------------------- | ---------- | -------------------------------------------------------------- |
+| `--host`             | (required) | Catalog server host(s), comma-separated or expandable patterns |
+| `--access-key`       | (required) | Access key (AWS key or OAuth client ID)                        |
+| `--secret-key`       | (required) | Secret key (AWS secret or OAuth client secret)                 |
+| `--region`           | us-east-1  | AWS region                                                     |
+| `--tls`              | false      | Use TLS                                                        |
+| `--external-catalog` | ""         | External catalog type (`polaris`)                              |
 
 ### Tree Configuration
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--catalog-name` | benchmarkcatalog | Catalog/warehouse name |
-| `--namespace-width` | varies | Width of N-ary namespace tree |
-| `--namespace-depth` | varies | Depth of namespace tree |
-| `--tables-per-ns` | varies | Tables per leaf namespace |
-| `--views-per-ns` | varies | Views per leaf namespace |
-| `--columns` | 10 | Columns per table/view schema |
-| `--properties` | 5 | Properties per entity |
-| `--base-location` | s3://benchmark | Base S3 location for tables |
+
+| Flag                | Default          | Description                   |
+| ------------------- | ---------------- | ----------------------------- |
+| `--catalog-name`    | benchmarkcatalog | Catalog/warehouse name        |
+| `--namespace-width` | varies           | Width of N-ary namespace tree |
+| `--namespace-depth` | varies           | Depth of namespace tree       |
+| `--tables-per-ns`   | varies           | Tables per leaf namespace     |
+| `--views-per-ns`    | varies           | Views per leaf namespace      |
+| `--columns`         | 10               | Columns per table/view schema |
+| `--properties`      | 5                | Properties per entity         |
+| `--base-location`   | s3://benchmark   | Base S3 location for tables   |
 
 ### Benchmark Control
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--concurrent` | 20 | Number of concurrent workers |
-| `--duration` | 5m | Benchmark duration |
-| `--autoterm` | false | Enable auto-termination when throughput stabilizes |
-| `--autoterm.dur` | 15s | Stability window for autoterm |
-| `--autoterm.pct` | 7.5 | Throughput variance threshold (%) |
+
+| Flag             | Default | Description                                        |
+| ---------------- | ------- | -------------------------------------------------- |
+| `--concurrent`   | 20      | Number of concurrent workers                       |
+| `--duration`     | 5m      | Benchmark duration                                 |
+| `--autoterm`     | false   | Enable auto-termination when throughput stabilizes |
+| `--autoterm.dur` | 15s     | Stability window for autoterm                      |
+| `--autoterm.pct` | 7.5     | Throughput variance threshold (%)                  |
 
 ## Tree Structure
 
 The `--namespace-width` and `--namespace-depth` flags define an N-ary tree of namespaces. Tables and views are created only in leaf namespaces.
 
 ### Calculations
+
 - Total namespaces = `(width^depth - 1) / (width - 1)` for width > 1
 - Leaf namespaces = `width^(depth-1)`
 - Total tables = `leaf_namespaces * tables_per_ns`
 - Total views = `leaf_namespaces * views_per_ns`
 
 ### Example Tree (width=2, depth=3)
+
 ```
 ns_0
 ├── ns_1
@@ -97,15 +102,18 @@ Requests are distributed across hosts using round-robin.
 Benchmarks Iceberg REST catalog read operations.
 
 ### Usage
+
 ```bash
 warp iceberg catalog-read [FLAGS]
 ```
 
 ### Workflow
+
 1. Creates N-ary namespace tree with tables and views
 2. Spawns workers that execute read operations from a shuffled pool
 
 ### Default Tree Configuration
+
 - `--namespace-width`: 2
 - `--namespace-depth`: 3
 - `--tables-per-ns`: 5
@@ -115,24 +123,26 @@ warp iceberg catalog-read [FLAGS]
 
 Weights control the proportion of each operation type:
 
-| Flag | Default | Operation |
-|------|---------|-----------|
-| `--ns-list-distrib` | 10 | List child namespaces |
-| `--ns-head-distrib` | 10 | Check namespace exists |
-| `--ns-get-distrib` | 10 | Load namespace properties |
-| `--table-list-distrib` | 10 | List tables in namespace |
-| `--table-head-distrib` | 10 | Check table exists |
-| `--table-get-distrib` | 10 | Load table metadata |
-| `--view-list-distrib` | 10 | List views in namespace |
-| `--view-head-distrib` | 10 | Check view exists |
-| `--view-get-distrib` | 10 | Load view metadata |
+| Flag                   | Default | Operation                 |
+| ---------------------- | ------- | ------------------------- |
+| `--ns-list-distrib`    | 10      | List child namespaces     |
+| `--ns-head-distrib`    | 10      | Check namespace exists    |
+| `--ns-get-distrib`     | 10      | Load namespace properties |
+| `--table-list-distrib` | 10      | List tables in namespace  |
+| `--table-head-distrib` | 10      | Check table exists        |
+| `--table-get-distrib`  | 10      | Load table metadata       |
+| `--view-list-distrib`  | 10      | List views in namespace   |
+| `--view-head-distrib`  | 10      | Check view exists         |
+| `--view-get-distrib`   | 10      | Load view metadata        |
 
 ### Operations Recorded
+
 - `NS_LIST`, `NS_HEAD`, `NS_GET`: Namespace operations
 - `TABLE_LIST`, `TABLE_HEAD`, `TABLE_GET`: Table operations
 - `VIEW_LIST`, `VIEW_HEAD`, `VIEW_GET`: View operations
 
 ### Example
+
 ```bash
 # Default read benchmark
 warp iceberg catalog-read \
@@ -156,15 +166,18 @@ warp iceberg catalog-read \
 Benchmarks Iceberg REST catalog commit generation by updating table/view properties.
 
 ### Usage
+
 ```bash
 warp iceberg catalog-commits [FLAGS]
 ```
 
 ### Workflow
+
 1. Creates N-ary namespace tree with tables and views
 2. Workers are split between table updates and view updates (default: 50/50 split of `--concurrent`)
 
 ### Default Tree Configuration
+
 - `--namespace-width`: 2
 - `--namespace-depth`: 3
 - `--tables-per-ns`: 5
@@ -172,21 +185,23 @@ warp iceberg catalog-commits [FLAGS]
 
 ### Additional Flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--table-commits-throughput` | 0 | Number of table update workers (0 = use `--concurrent/2`) |
-| `--view-commits-throughput` | 0 | Number of view update workers (0 = use `--concurrent/2`) |
-| `--max-retries` | 4 | Retries on 409 Conflict or 500 errors |
-| `--retry-backoff` | 100ms | Initial backoff duration |
-| `--backoff-max` | 60s | Maximum backoff duration |
+| Flag                         | Default | Description                                               |
+| ---------------------------- | ------- | --------------------------------------------------------- |
+| `--table-commits-throughput` | 0       | Number of table update workers (0 = use `--concurrent/2`) |
+| `--view-commits-throughput`  | 0       | Number of view update workers (0 = use `--concurrent/2`)  |
+| `--max-retries`              | 4       | Retries on 409 Conflict or 500 errors                     |
+| `--retry-backoff`            | 100ms   | Initial backoff duration                                  |
+| `--backoff-max`              | 60s     | Maximum backoff duration                                  |
 
 **Note:** When you set explicit values, `--concurrent` is ignored. Total workers = `table-commits-throughput + view-commits-throughput`.
 
 ### Operations Recorded
+
 - `TABLE_UPDATE`: Table property update
 - `VIEW_UPDATE`: View property update
 
 ### Example
+
 ```bash
 # Basic commit benchmark
 warp iceberg catalog-commits \
@@ -217,15 +232,18 @@ warp iceberg catalog-commits \
 Benchmarks mixed read/write workload with configurable operation distribution.
 
 ### Usage
+
 ```bash
 warp iceberg catalog-mixed [FLAGS]
 ```
 
 ### Workflow
+
 1. Creates N-ary namespace tree with tables and views
 2. Workers execute random mix of read and update operations from shuffled pool
 
 ### Default Tree Configuration
+
 - `--namespace-width`: 2
 - `--namespace-depth`: 3
 - `--tables-per-ns`: 5
@@ -235,25 +253,27 @@ warp iceberg catalog-mixed [FLAGS]
 
 All read operations from catalog-read plus update operations:
 
-| Flag | Default | Operation |
-|------|---------|-----------|
-| `--ns-update-distrib` | 0 | Update namespace properties |
-| `--table-update-distrib` | 5 | Update table properties |
-| `--view-update-distrib` | 5 | Update view properties |
+| Flag                     | Default | Operation                   |
+| ------------------------ | ------- | --------------------------- |
+| `--ns-update-distrib`    | 0       | Update namespace properties |
+| `--table-update-distrib` | 5       | Update table properties     |
+| `--view-update-distrib`  | 5       | Update view properties      |
 
 ### Additional Flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--max-retries` | 5 | Retries for update operations on conflict |
-| `--retry-backoff` | 100ms | Initial backoff duration |
-| `--backoff-max` | 2s | Maximum backoff duration |
+| Flag              | Default | Description                               |
+| ----------------- | ------- | ----------------------------------------- |
+| `--max-retries`   | 5       | Retries for update operations on conflict |
+| `--retry-backoff` | 100ms   | Initial backoff duration                  |
+| `--backoff-max`   | 2s      | Maximum backoff duration                  |
 
 ### Operations Recorded
+
 - All read operations from catalog-read
 - `NS_UPDATE`, `TABLE_UPDATE`, `VIEW_UPDATE`: Update operations
 
 ### Example
+
 ```bash
 # Default mixed workload
 warp iceberg catalog-mixed \
@@ -277,11 +297,13 @@ warp iceberg catalog-mixed \
 Run a sustained Iceberg workload with controlled request rates. Designed for long-running tests with specific RPS limits for commits and reads.
 
 ### Usage
+
 ```bash
 warp iceberg sustained [FLAGS]
 ```
 
 ### Workflow
+
 1. Creates warehouse namespace/table tree structure
 2. Downloads or generates parquet data files
 3. Optionally uploads files once during prepare (`--skip-upload`)
@@ -290,6 +312,7 @@ warp iceberg sustained [FLAGS]
    - **Reads**: LoadTable operations (enabled with `--simulate-read`, controlled by `--read-rps-limit`)
 
 ### Default Tree Configuration
+
 - `--namespace-width`: 1
 - `--namespace-depth`: 1
 - `--tables-per-ns`: 1
@@ -297,46 +320,53 @@ warp iceberg sustained [FLAGS]
 ### Additional Flags
 
 #### Data Configuration
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--num-files` | 10 | Parquet files to generate (used for commits) |
-| `--rows-per-file` | 10000 | Rows per parquet file |
-| `--cache-dir` | /tmp/warp-iceberg-cache | Local cache for data files |
+
+| Flag              | Default                 | Description                                  |
+| ----------------- | ----------------------- | -------------------------------------------- |
+| `--num-files`     | 10                      | Parquet files to generate (used for commits) |
+| `--rows-per-file` | 10000                   | Rows per parquet file                        |
+| `--cache-dir`     | /tmp/warp-iceberg-cache | Local cache for data files                   |
 
 #### TPC-DS Data
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--tpcds` | false | Use TPC-DS benchmark data from GCS |
-| `--scale-factor` | sf100 | TPC-DS scale (sf1, sf10, sf100, sf1000) |
-| `--tpcds-table` | store_sales | TPC-DS table name |
+
+| Flag             | Default     | Description                             |
+| ---------------- | ----------- | --------------------------------------- |
+| `--tpcds`        | false       | Use TPC-DS benchmark data from GCS      |
+| `--scale-factor` | sf100       | TPC-DS scale (sf1, sf10, sf100, sf1000) |
+| `--tpcds-table`  | store_sales | TPC-DS table name                       |
 
 #### Commit Control
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--files-per-commit` | 1 | Number of files to include per commit |
-| `--skip-upload` | true | Upload files once in prepare, then only benchmark commits |
-| `--rps-limit` | 0 | RPS limit for commit workers (0 = unlimited) |
+
+| Flag                 | Default | Description                                               |
+| -------------------- | ------- | --------------------------------------------------------- |
+| `--files-per-commit` | 1       | Number of files to include per commit                     |
+| `--skip-upload`      | true    | Upload files once in prepare, then only benchmark commits |
+| `--rps-limit`        | 0       | RPS limit for commit workers (0 = unlimited)              |
 
 #### Read Simulation
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--simulate-read` | false | Enable parallel LoadTable reads during benchmark |
-| `--read-concurrent` | 20 | Number of read workers |
-| `--read-rps-limit` | 400 | RPS limit for read workers (0 = unlimited) |
+
+| Flag                | Default | Description                                      |
+| ------------------- | ------- | ------------------------------------------------ |
+| `--simulate-read`   | false   | Enable parallel LoadTable reads during benchmark |
+| `--read-concurrent` | 20      | Number of read workers                           |
+| `--read-rps-limit`  | 400     | RPS limit for read workers (0 = unlimited)       |
 
 #### Retry/Conflict Handling
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--max-retries` | 4 | Maximum commit retries on conflict |
-| `--backoff-base` | 100ms | Base backoff duration for retries |
-| `--backoff-max` | 60s | Maximum backoff duration |
+
+| Flag             | Default | Description                        |
+| ---------------- | ------- | ---------------------------------- |
+| `--max-retries`  | 4       | Maximum commit retries on conflict |
+| `--backoff-base` | 100ms   | Base backoff duration for retries  |
+| `--backoff-max`  | 60s     | Maximum backoff duration           |
 
 ### Operations Recorded
+
 - `UPLOAD`: Parquet file upload to S3 (when not using `--skip-upload`)
 - `COMMIT`: Iceberg table commit with file references
 - `TABLE_GET`: LoadTable read operations (when `--simulate-read` enabled)
 
 ### Example
+
 ```bash
 # Sustained commits (1 every 2 sec) with 400 reads/sec
 warp iceberg sustained \
@@ -405,6 +435,7 @@ warp iceberg catalog-read \
 ```
 
 In distributed mode:
+
 - Only the first client (ClientIdx=0) creates and cleans up the dataset
 - All clients participate in the benchmark phase
 - Results are merged by the server
@@ -429,12 +460,14 @@ warp merge client1.csv.zst client2.csv.zst
 ### Metrics Recorded
 
 Each operation records:
+
 - Operation type (e.g., NS_LIST, TABLE_GET)
 - Start/End timestamps (nanosecond precision)
 - Entity identifier (namespace path, table name)
 - Error message (if failed)
 
 ### Analysis Output
+
 - Throughput (ops/sec)
 - Latency percentiles (p50, p90, p99, p99.9)
 - Error counts and rates

--- a/scripts/release-post-transform.sh
+++ b/scripts/release-post-transform.sh
@@ -76,11 +76,15 @@ for arch in amd64 arm64; do
 		--ignore
 
 	# pkger names the packages after the app, so rename on the way out to keep
-	# them distinct from the stock warp packages already in the layout.
+	# them distinct from the stock warp packages already in the layout. Its own
+	# checksums are written against the pre-rename names, so regenerate them
+	# here rather than carrying across files that no longer match.
 	for pkg in "${pkg_dir}"/warp_*.deb "${pkg_dir}"/warp-*.rpm "${pkg_dir}"/warp_*.apk; do
 		[ -e "${pkg}" ] || continue
 		base="$(basename "${pkg}")"
-		mv "${pkg}" "${layout_dir}/${base/warp/warp-rdma}"
+		renamed="${base/warp/warp-rdma}"
+		mv "${pkg}" "${layout_dir}/${renamed}"
+		(cd "${layout_dir}" && sha256sum "${renamed}" >"${renamed}.sha256sum")
 	done
 
 	echo "post-transform: RDMA packages placed in ${layout_dir}:"


### PR DESCRIPTION
Follow-up to #501. Two things: a guide for people standing up an RDMA client, and a fix for a gap I found while verifying that PR's release artifacts.

## RDMA.md

The RDMA material outgrew the README, so it moves to `RDMA.md`, written in the order someone actually works: install the package or archive, configure cuObj, run a benchmark, read the errors when it does not work. The README keeps a short summary and a link.

The part nothing documented today is **`cuobj.json`**. Warp does not install it, and without one naming the client NIC every transfer quietly falls back to HTTP — which, given the fallback is silent, is the failure this guide most needs to prevent.

The settings and the shape of the example come from clients that are actually working rather than from the vendored sample: pin a single NIC, multipath off, logging at `ERROR` rather than the sample's `TRACE`, and `use_pci_p2pdma` with `rdma_peer_type: dmabuf` for GPU-Direct. The sample's `<client-nic-ip>` placeholder is called out, since copying it unedited is the easiest way to end up on HTTP without noticing.

Troubleshooting covers the errors this work actually produced, including the CUDA runtime/driver mismatch (`the oldest CUDA runtime on this host is X, but the NVIDIA driver only supports up to Y`) and the loader error when the cuObj libraries are not found.

## The RDMA packages had no checksums

Verifying #501's `release-test` artifact turned this up:

```
warp_10.0.0_amd64.deb           warp_10.0.0_amd64.deb.sha256sum
warp-rdma_10.0.0_amd64.deb      (none)
```

pkger writes checksums against the names it chose, and the post-transform hook renames the packages to `warp-rdma_*` on the way into the layout, which invalidates them. They were being dropped, so the RDMA packages shipped unchecksummed while the stock ones did not. The hook now regenerates them after the rename; verified with `sha256sum -c`.

## Formatting

A second commit runs prettier over the yaml and markdown. It is kept separate so the content is reviewable on its own. I also repaired a stray terminal escape sequence that had been written into `.gitignore`, which would have broken the `*.exe` rule, and added `warp-release/` to it since a local hook run creates that directory.

## Verification

`go build`, `golangci-lint`, `bash -n`, `goreleaser check`, YAML parse of every workflow, and `prettier --check` all pass. The package installs and runs — I installed the deb on a GPU host and confirmed it resolves its bundled cuObj libraries from `/usr/lib/warp` with no `LD_LIBRARY_PATH` and accepts `--rdma=cpu`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive S3 over RDMA documentation covering setup, configuration, runtime usage, distributed operation, and troubleshooting.
  - Expanded guidance for RDMA, benchmarks, analysis, profiling, metrics, and Iceberg REST catalog benchmarks.

- **Bug Fixes**
  - Release packages now receive SHA-256 checksums after RDMA package renaming.
  - Release validation verifies checksum files and package integrity.

- **Documentation**
  - Improved formatting and clarity across project, RDMA, benchmark, and release documentation.

- **Chores**
  - Normalized workflow and release configuration formatting.
  - Excluded release output from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->