### PR TITLE
build(rdma): provision the release host and publish warp-rdma for arm64

### DIFF
--- a/.github/workflows/qreleaser-test.yml
+++ b/.github/workflows/qreleaser-test.yml
@@ -35,61 +35,28 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      # The release builds the warp-rdma variant, which links libminiocpp
-      # through cgo, so the runner needs the same RDMA prerequisites as a real
-      # release host. Without them the pipeline fails on miniocpp/c_api.h.
-      - name: Checkout minio-cpp
-        uses: actions/checkout@v4
-        with:
-          repository: minio/minio-cpp
-          path: "minio-cpp"
-          persist-credentials: false
-
-      # Pinned: vcpkg's port scripts track the newest CMake, and a floating
-      # checkout breaks against whatever CMake the runner image ships.
-      - name: Checkout vcpkg
-        uses: actions/checkout@v4
-        with:
-          repository: microsoft/vcpkg
-          ref: "2026.07.29"
-          path: "vcpkg"
-          persist-credentials: false
-
-      - name: Install RDMA dependencies
-        run: |
-          sudo apt-get -qy update
-          sudo apt-get -qy install libibverbs-dev librdmacm-dev libnuma-dev
-
       - name: Set up CMake
         uses: lukka/get-cmake@v4.4.2
 
-      - name: Build and install libminiocpp.so with RDMA
-        shell: bash
-        run: |
-          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
-          cd minio-cpp
-          ../vcpkg/vcpkg install
-          cmake . -B ./build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DCMAKE_INSTALL_PREFIX=/usr/local \
-            -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
-            -DMINIO_CPP_ENABLE_RDMA:BOOL=ON
-          cmake --build ./build --config Release -j 4
-          sudo cmake --install ./build
-          sudo cp -P vendor/cuobj/lib/x86_64/* /usr/local/lib/
-          # libminiocpp is static; its vcpkg archives must sit beside it to link.
-          sudo cp -P vcpkg_installed/*/lib/*.a /usr/local/lib/
-          sudo ldconfig
-          # The libraries are installed system-wide now, and the workspace is
-          # what qreleaser releases from, so leave no extra trees behind in it.
-          cd "${GITHUB_WORKSPACE}" && rm -rf minio-cpp vcpkg
-
+      # Go before the prefixes: the provisioning script link-tests each
+      # architecture with a smoke build when a toolchain is available.
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           cache: false
+
+      # The release builds warp-rdma for linux/amd64 and linux/arm64, and both
+      # link libminiocpp through cgo, so the runner needs the same prefixes as a
+      # real release host. Without them the pipeline fails on miniocpp/c_api.h,
+      # or on the missing aarch64 compiler.
+      #
+      # Running the release-host script rather than repeating its steps keeps CI
+      # from drifting away from how the host is actually provisioned, and covers
+      # the arm64 cross build on every PR. It keeps its checkouts outside the
+      # workspace, which is what qreleaser releases from.
+      - name: Provision the RDMA prefixes
+        run: ./scripts/setup-rdma-release-host.sh
 
       - name: Configure git
         run: |
@@ -184,6 +151,32 @@ jobs:
             (cd "${ARCH_DIR}" && sha256sum -c "$(basename "${pkg}").sha256sum")
           done
           [ "${found}" = 1 ] || { echo "no RDMA packages in ${ARCH_DIR}" >&2; exit 1; }
+
+      - name: Verify arm64 RDMA Artifacts
+        env:
+          ARM_DIR: ${{ github.workspace }}/warp-release/${{ steps.release-type.outputs.type_dir }}/linux-arm64
+        run: |
+          # The arm64 flavor is cross-built and cannot run here, so assert the ELF
+          # target instead. Both architectures are named warp inside their dist
+          # directories, so without this the arm64 flavor could be an amd64 binary
+          # and nothing would notice.
+          readelf -h "${ARM_DIR}/warp.rdma" | grep -q AArch64
+
+          found=0
+          for pkg in "${ARM_DIR}"/warp-rdma*.deb \
+                     "${ARM_DIR}"/warp-rdma*.rpm \
+                     "${ARM_DIR}"/warp-rdma*.apk; do
+            [ -e "${pkg}" ] || continue
+            found=1
+            (cd "${ARM_DIR}" && sha256sum -c "$(basename "${pkg}").sha256sum")
+          done
+          [ "${found}" = 1 ] || { echo "no arm64 RDMA packages in ${ARM_DIR}" >&2; exit 1; }
+
+          # The bundled cuObj libraries come from a per-architecture prefix, so
+          # check the payload too rather than trusting the package name.
+          dpkg-deb -x "${ARM_DIR}"/warp-rdma*.deb /tmp/armdeb
+          readelf -h /tmp/armdeb/usr/lib/warp/libcuobjclient.so.1.2.0 | grep -q AArch64
+          readelf -h /tmp/armdeb/usr/local/bin/warp | grep -q AArch64
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.goreleaser/qreleaser.yaml
+++ b/.goreleaser/qreleaser.yaml
@@ -56,6 +56,11 @@ builds:
   # WARP_SKIP_RDMA=true to drop the build from a release when the host is not
   # provisioned for it.
   #
+  # skip covers the whole build and goreleaser has no per-architecture equivalent,
+  # so a host provisioned for one architecture only (--no-cross) fails the release
+  # rather than publishing the architecture it can. Such a host has to set
+  # WARP_SKIP_RDMA=true.
+  #
   # Note this binary resolves libminiocpp and the cuObj libraries from the host
   # at run time. The self-contained archive with those bundled is built
   # separately by scripts/build-rdma.sh.

--- a/.goreleaser/qreleaser.yaml
+++ b/.goreleaser/qreleaser.yaml
@@ -43,15 +43,18 @@ builds:
   # the binary stays warp, and the release directory ends up with warp.rdma and
   # warp.<version>.rdma next to the stock warp.
   #
-  # It links libminiocpp through cgo, so unlike the build above it cannot be
-  # cross-compiled and is limited to the release host's own architecture. CUDA
-  # is loaded at run time rather than linked, so one binary serves --rdma=cpu
-  # and --rdma=gpu and no CUDA package is needed to build.
+  # It links libminiocpp through cgo, so unlike the build above it needs the C++
+  # side present for every architecture it publishes. CUDA is loaded at run time
+  # rather than linked, so one binary serves --rdma=cpu and --rdma=gpu and no
+  # CUDA package is needed to build.
   #
-  # The release host needs libminiocpp built with RDMA plus libibverbs,
-  # librdmacm and libnuma. Point MINIOCPP_PREFIX at the install prefix if it is
-  # not /usr/local. Set WARP_SKIP_RDMA=true to drop the build from a release
-  # when the host is not provisioned for it.
+  # The release host is expected to be amd64 with both prefixes provisioned by
+  # scripts/setup-rdma-release-host.sh: amd64 natively at MINIOCPP_PREFIX, arm64
+  # cross-built at MINIOCPP_PREFIX/aarch64-linux-gnu (see the arm64 override
+  # below). It also needs libibverbs, librdmacm and libnuma for both. Point
+  # MINIOCPP_PREFIX at the install prefix if it is not /usr/local, and set
+  # WARP_SKIP_RDMA=true to drop the build from a release when the host is not
+  # provisioned for it.
   #
   # Note this binary resolves libminiocpp and the cuObj libraries from the host
   # at run time. The self-contained archive with those bundled is built
@@ -79,6 +82,20 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
+    # arm64 is cross-built: cgo needs the aarch64 compiler and the arm64
+    # libminiocpp prefix, which is a subdirectory of MINIOCPP_PREFIX rather than
+    # the prefix itself. An override rather than {{ .Arch }} templating so the
+    # amd64 link line stays byte for byte what it was before arm64 was added.
+    overrides:
+      - goos: linux
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
+          - CC=aarch64-linux-gnu-gcc
+          - CXX=aarch64-linux-gnu-g++
+          - CGO_CFLAGS={{ envOrDefault "CGO_CFLAGS" "" }} -I{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/aarch64-linux-gnu/include
+          - CGO_LDFLAGS={{ envOrDefault "CGO_LDFLAGS" "" }} -L{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/aarch64-linux-gnu/lib -Wl,-rpath-link,{{ envOrDefault "MINIOCPP_PREFIX" "/usr/local" }}/aarch64-linux-gnu/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags {{ mustReadFile "scripts/rdma-cgo-libs.txt" }}
     flags:
       - -trimpath
       - --tags=kqueue,rdma

--- a/RDMA.md
+++ b/RDMA.md
@@ -23,8 +23,7 @@ as if they were RDMA numbers.
 
 RDMA support is compiled in, and the standard warp binaries are built without
 cgo, so they refuse `--rdma` at startup. Use one of the builds below instead.
-All of them are linux/amd64: the RDMA build links libminiocpp through cgo, so it
-cannot be cross-compiled.
+They are published for linux/amd64 and linux/arm64.
 
 ### Package
 
@@ -42,6 +41,9 @@ Then install:
 λ sudo apt install ./warp-rdma_<version>_amd64.deb      # Debian, Ubuntu
 λ sudo apk add --allow-untrusted warp-rdma_<version>_x86_64.apk
 ```
+
+On arm64 hosts the same packages are named `warp-rdma-<version>-1.aarch64.rpm`,
+`warp-rdma_<version>_arm64.deb` and `warp-rdma_<version>_aarch64.apk`.
 
 apk needs `--allow-untrusted` because the package is not signed with a key in
 the host keyring. Verify the checksum above before using it. The published

--- a/RDMA.md
+++ b/RDMA.md
@@ -23,8 +23,7 @@ as if they were RDMA numbers.
 
 RDMA support is compiled in, and the standard warp binaries are built without
 cgo, so they refuse `--rdma` at startup. Use one of the builds below instead.
-The packages and binaries are published for linux/amd64 and linux/arm64. The
-archive is built per host, so only the amd64 one is published.
+They are published for linux/amd64 and linux/arm64.
 
 ### Package
 
@@ -58,7 +57,7 @@ the same as the standard package, so install one or the other rather than both.
 ### Archive
 
 ```bash
-λ tar xzf warp-rdma_linux_amd64.tar.gz
+λ tar xzf warp-rdma_linux_amd64.tar.gz   # or warp-rdma_linux_arm64.tar.gz
 λ ./warp-rdma/warp --version
 ```
 

--- a/RDMA.md
+++ b/RDMA.md
@@ -23,7 +23,8 @@ as if they were RDMA numbers.
 
 RDMA support is compiled in, and the standard warp binaries are built without
 cgo, so they refuse `--rdma` at startup. Use one of the builds below instead.
-They are published for linux/amd64 and linux/arm64.
+The packages and binaries are published for linux/amd64 and linux/arm64. The
+archive is built per host, so only the amd64 one is published.
 
 ### Package
 

--- a/scripts/rdma-cross/aarch64-linux-gnu.cmake
+++ b/scripts/rdma-cross/aarch64-linux-gnu.cmake
@@ -1,0 +1,23 @@
+# CMake toolchain for cross-building libminiocpp (and its vcpkg dependencies)
+# to linux/arm64 from an amd64 release host.
+#
+# Used by scripts/setup-rdma-release-host.sh, both directly for the minio-cpp
+# project and chainloaded by scripts/rdma-cross/triplets/arm64-linux.cmake so
+# vcpkg builds the dependency tree with the same compiler.
+
+set(CMAKE_SYSTEM_NAME Linux)
+
+# minio-cpp reads CMAKE_SYSTEM_PROCESSOR to pick vendor/cuobj/lib/<arch>, so
+# this is what makes an RDMA build resolve the aarch64 cuObj libraries.
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+# Debian/Ubuntu foreign-architecture packages -- the arm64 libibverbs, librdmacm
+# and libnuma an RDMA build links -- install under /usr/lib/<triplet>, which
+# cmake only searches when told the library architecture.
+set(CMAKE_LIBRARY_ARCHITECTURE aarch64-linux-gnu)
+
+# Host tools stay executable; nothing else should come from the host.
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/scripts/rdma-cross/aarch64-linux-gnu.cmake
+++ b/scripts/rdma-cross/aarch64-linux-gnu.cmake
@@ -19,5 +19,9 @@ set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
 # cmake only searches when told the library architecture.
 set(CMAKE_LIBRARY_ARCHITECTURE aarch64-linux-gnu)
 
-# Host tools stay executable; nothing else should come from the host.
+# Host build tools stay executable. Libraries and headers are not confined to a
+# find-root path, because Debian shares /usr/include across architectures;
+# CMAKE_LIBRARY_ARCHITECTURE above is what steers library lookups to the arm64
+# directory, and verify_prefix in scripts/setup-rdma-release-host.sh checks the
+# ELF machine of what comes out.
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/scripts/rdma-cross/triplets/arm64-linux.cmake
+++ b/scripts/rdma-cross/triplets/arm64-linux.cmake
@@ -1,0 +1,16 @@
+# vcpkg overlay triplet for cross-building the libminiocpp dependency tree to
+# linux/arm64 from an amd64 host.
+#
+# vcpkg's own arm64-linux triplet assumes the default compiler can produce arm64
+# objects, which on an amd64 host it cannot. This overlay differs from it only by
+# chainloading the aarch64 toolchain.
+
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+
+# libminiocpp is linked statically into warp, so its dependencies must be static
+# too; see scripts/rdma-cgo-libs.txt for the resulting link line.
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../aarch64-linux-gnu.cmake")

--- a/scripts/release-post-transform.sh
+++ b/scripts/release-post-transform.sh
@@ -50,12 +50,19 @@ for arch in amd64 arm64; do
 	layout_dir="warp-release/${RELEASE_TYPE}/linux-${arch}"
 	binary="${layout_dir}/warp.${VERSION_TAG}.rdma"
 
-	# The RDMA build is limited to the release host's own architecture, so the
-	# other one is legitimately absent rather than an error.
+	# A release host provisioned for only one architecture legitimately produces
+	# only that binary, so a missing one is a skip rather than an error.
 	if [ ! -f "${binary}" ]; then
 		echo "post-transform: no RDMA binary for linux-${arch}, skipping"
 		continue
 	fi
+
+	# arm64 is cross-built against its own prefix; see
+	# scripts/setup-rdma-release-host.sh and .goreleaser/qreleaser.yaml.
+	case "${arch}" in
+	arm64) arch_prefix="${MINIOCPP_PREFIX}/aarch64-linux-gnu" ;;
+	*) arch_prefix="${MINIOCPP_PREFIX}" ;;
+	esac
 
 	# pkger reads <releaseDir>/<goos>-<goarch>/<binary-name>.<version>, while the
 	# q layout names the flavor <binary>.<version>.rdma. Stage a copy under the
@@ -64,9 +71,9 @@ for arch in amd64 arm64; do
 	pkg_dir="${STAGE_DIR}/release/linux-${arch}"
 	mkdir -p "${pkg_dir}" "${STAGE_DIR}/lib/${arch}"
 	cp -p "${binary}" "${pkg_dir}/warp.rdma.${VERSION_TAG}"
-	cp -P "${MINIOCPP_PREFIX}"/lib/libcuobjclient.so* \
-		"${MINIOCPP_PREFIX}"/lib/libcufile.so* \
-		"${MINIOCPP_PREFIX}"/lib/libcufile_rdma.so* "${STAGE_DIR}/lib/${arch}/"
+	cp -P "${arch_prefix}"/lib/libcuobjclient.so* \
+		"${arch_prefix}"/lib/libcufile.so* \
+		"${arch_prefix}"/lib/libcufile_rdma.so* "${STAGE_DIR}/lib/${arch}/"
 
 	echo "post-transform: packaging RDMA artifacts for linux-${arch} (${VERSION_TAG})"
 	pkger -a warp --binary-name warp.rdma -r "${VERSION_TAG}" -l AGPLv3 \

--- a/scripts/setup-rdma-release-host.sh
+++ b/scripts/setup-rdma-release-host.sh
@@ -70,7 +70,7 @@ while [ $# -gt 0 ]; do
 		VERIFY_ONLY=1
 		;;
 	-h | --help)
-		sed -n '2,42p' "$0"
+		sed -n '2,38p' "$0"
 		exit 0
 		;;
 	*)
@@ -117,6 +117,11 @@ if [ "${CROSS}" = 1 ]; then
 	else
 		echo ">>> cross-building amd64 from ${HOST_ARCH} is not supported; provisioning ${HOST_ARCH} only" >&2
 	fi
+else
+	# qreleaser publishes both architectures from one build and goreleaser cannot
+	# skip just one of them, so a half-provisioned release host fails the release.
+	echo ">>> --no-cross: provisioning ${HOST_ARCH} only. A release host needs both" >&2
+	echo ">>> architectures, or WARP_SKIP_RDMA=true to drop the RDMA build entirely" >&2
 fi
 
 arch_prefix() {
@@ -178,6 +183,13 @@ arch_cc() {
 	case "$1" in
 	arm64) [ "${HOST_ARCH}" = arm64 ] && echo gcc || echo aarch64-linux-gnu-gcc ;;
 	amd64) [ "${HOST_ARCH}" = amd64 ] && echo gcc || echo x86_64-linux-gnu-gcc ;;
+	esac
+}
+
+arch_cxx() {
+	case "$1" in
+	arm64) [ "${HOST_ARCH}" = arm64 ] && echo g++ || echo aarch64-linux-gnu-g++ ;;
+	amd64) [ "${HOST_ARCH}" = amd64 ] && echo g++ || echo x86_64-linux-gnu-g++ ;;
 	esac
 }
 
@@ -274,10 +286,16 @@ if command -v apt-get >/dev/null 2>&1; then
 		# The amd64 archive carries no arm64 packages; they live on ports.ubuntu.com.
 		# Its arm64 index then 404s harmlessly, so update stays tolerant.
 		if [ ! -f /etc/apt/sources.list.d/arm64-ports.list ]; then
-			codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
-			printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s main universe\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-updates main universe\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-security main universe\n' \
-				"${codename}" "${codename}" "${codename}" |
-				run_privileged tee /etc/apt/sources.list.d/arm64-ports.list >/dev/null
+			distro="$(. /etc/os-release && echo "${ID:-}")"
+			codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-}")"
+			# Only Ubuntu splits arm64 onto a separate mirror; Debian serves every
+			# architecture from its own archive, so adding this there would mix
+			# distributions on a host that keeps the file.
+			if [ "${distro}" = ubuntu ] && [ -n "${codename}" ]; then
+				printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s main universe\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-updates main universe\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-security main universe\n' \
+					"${codename}" "${codename}" "${codename}" |
+					run_privileged tee /etc/apt/sources.list.d/arm64-ports.list >/dev/null
+			fi
 		fi
 		run_privileged apt-get -qq update || true
 		# libibverbs-dev and friends are Multi-Arch: same -- install both arches
@@ -318,6 +336,10 @@ sync_checkout() {
 		before="$(git -C "${dir}" rev-parse HEAD)"
 		git -C "${dir}" remote set-url origin "${repo}"
 		git -C "${dir}" fetch --depth 1 origin "${ref}"
+		# A tracked file modified in place would make the checkout below refuse to
+		# run. Untracked build output is left alone: it is what makes a rerun
+		# incremental, and a moved ref drops it explicitly.
+		git -C "${dir}" reset --hard -q HEAD
 		git -C "${dir}" checkout --detach FETCH_HEAD
 	else
 		rm -rf "${dir}"
@@ -447,6 +469,7 @@ smoke_build() {
 	CGO_ENABLED=1 \
 		GOOS=linux GOARCH="${arch}" \
 		CC="$(arch_cc "${arch}")" \
+		CXX="$(arch_cxx "${arch}")" \
 		CGO_CFLAGS="-I${prefix}/include" \
 		CGO_LDFLAGS="-L${prefix}/lib -Wl,-rpath-link,${prefix}/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags $(cat "${REPO_DIR}/scripts/rdma-cgo-libs.txt")" \
 		go build -trimpath -tags=kqueue,rdma -o "${out}" .
@@ -491,11 +514,12 @@ if command -v go >/dev/null 2>&1 && [ -f "${REPO_DIR}/go.mod" ]; then
 	SMOKE_BUILT=1
 else
 	echo ">>> WARNING: no Go toolchain or no go.mod under ${REPO_DIR}; skipped the smoke build" >&2
-	echo ">>> run --verify-only from a warp checkout to link-test before releasing" >&2
+	echo ">>> rerun from a warp checkout to link-test before releasing; --verify-only" >&2
+	echo ">>> rechecks the prefixes and links nothing" >&2
 fi
 
 if [ "${SMOKE_BUILT}" = 1 ]; then
 	echo ">>> release host provisioned and link-tested for: ${TARGETS[*]}"
 else
-	echo ">>> release host provisioned for: ${TARGETS[*]}, smoke build SKIPPED"
+	echo ">>> release host provisioned for: ${TARGETS[*]}; link compatibility UNVERIFIED"
 fi

--- a/scripts/setup-rdma-release-host.sh
+++ b/scripts/setup-rdma-release-host.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# Provision a release host so qreleaser can build the `warp-rdma` target.
+#
+# The RDMA build links libminiocpp through cgo, so it cannot be cross-compiled
+# and the toolchain has to exist on the release host itself -- the qreleaser
+# checkout is wiped per run, so this cannot live in the build. Run it once per
+# host (again when the pinned minio-cpp ref moves). It is idempotent.
+#
+# Installs into ${PREFIX} (default /usr/local, which is what
+# .goreleaser/qreleaser.yaml and scripts/release-post-transform.sh look for
+# when MINIOCPP_PREFIX is unset):
+#
+#   - libminiocpp.a built with RDMA enabled, plus its headers
+#   - the vcpkg static archives it needs to link (scripts/rdma-cgo-libs.txt)
+#   - the vendored cuObj/cuFile shared objects, which the release packaging
+#     copies out of the prefix
+#
+# The host must already supply the RDMA stack itself -- libibverbs, librdmacm
+# and libnuma with their -dev packages -- because those are tied to its kernel
+# driver. No CUDA package is needed: CUDA is dlopened at run time.
+#
+# Usage:
+#   scripts/setup-rdma-release-host.sh [--prefix DIR] [--work DIR] [--verify-only]
+#
+# Any existing libminiocpp in the prefix is moved aside to a timestamped
+# backup directory rather than overwritten.
+
+set -euo pipefail
+
+PREFIX="${PREFIX:-/usr/local}"
+WORK="${WORK:-${HOME}/.warp-rdma-host}"
+VERIFY_ONLY=0
+
+need_value() {
+	[ $# -ge 2 ] || {
+		echo "$1 requires a value" >&2
+		exit 1
+	}
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--prefix)
+		need_value "$@"
+		PREFIX="$2"
+		shift
+		;;
+	--work)
+		need_value "$@"
+		WORK="$2"
+		shift
+		;;
+	--verify-only)
+		VERIFY_ONLY=1
+		;;
+	-h | --help)
+		sed -n '2,25p' "$0"
+		exit 0
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		exit 1
+		;;
+	esac
+	shift
+done
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+case "$(uname -s)" in
+Linux) ;;
+*)
+	echo "RDMA release builds are Linux only (got $(uname -s))" >&2
+	exit 1
+	;;
+esac
+
+case "$(uname -m)" in
+x86_64) CUOBJ_ARCH=x86_64 ;;
+aarch64 | arm64) CUOBJ_ARCH=aarch64 ;;
+*)
+	echo "unsupported architecture: $(uname -m) (RDMA builds are linux/amd64 and linux/arm64 only)" >&2
+	exit 1
+	;;
+esac
+
+# Pinned in lockstep with scripts/build-rdma.sh and .github/workflows/go-rdma.yml:
+# a floating minio-cpp is what leaves a host with headers too old for the
+# minio-go revision in go.mod, and vcpkg's port scripts track the newest CMake.
+MINIO_CPP_REF="${MINIO_CPP_REF:-v0.5.0}"
+MINIO_CPP_REPO="${MINIO_CPP_REPO:-https://github.com/minio/minio-cpp}"
+VCPKG_REF="${VCPKG_REF:-2026.07.29}"
+CMAKE_MIN="3.31"
+CMAKE_VERSION="${CMAKE_VERSION:-3.31.6}"
+
+as_root() {
+	if [ -w "${PREFIX}" ]; then
+		"$@"
+	else
+		sudo "$@"
+	fi
+}
+
+# Assert the prefix can satisfy the exact link line qreleaser composes, so a
+# half-provisioned host fails here in seconds instead of 20 minutes into a
+# release.
+verify_prefix() {
+	local missing=0 lib name
+
+	if [ ! -f "${PREFIX}/include/miniocpp/c_api.h" ]; then
+		echo "MISSING: ${PREFIX}/include/miniocpp/c_api.h (libminiocpp too old for the minio-go revision in go.mod)" >&2
+		missing=1
+	fi
+
+	for lib in $(tr ' ' '\n' <"${REPO_DIR}/scripts/rdma-cgo-libs.txt" | sed -n 's/^-l//p'); do
+		case "${lib}" in
+		# Supplied by the toolchain and the host RDMA stack, not the prefix.
+		stdc++ | m | dl | pthread) continue ;;
+		esac
+		name="lib${lib}"
+		if ! compgen -G "${PREFIX}/lib/${name}.a" >/dev/null &&
+			! compgen -G "${PREFIX}/lib/${name}.so*" >/dev/null; then
+			echo "MISSING: ${PREFIX}/lib/${name}.{a,so}" >&2
+			missing=1
+		fi
+	done
+
+	# scripts/release-post-transform.sh copies these out of the prefix by name.
+	for name in libcuobjclient.so libcufile.so libcufile_rdma.so; do
+		if ! compgen -G "${PREFIX}/lib/${name}*" >/dev/null; then
+			echo "MISSING: ${PREFIX}/lib/${name}* (needed by release packaging)" >&2
+			missing=1
+		fi
+	done
+
+	[ "${missing}" = 0 ] || return 1
+	echo ">>> ${PREFIX} satisfies the RDMA link line"
+}
+
+if [ "${VERIFY_ONLY}" = 1 ]; then
+	verify_prefix
+	exit 0
+fi
+
+echo ">>> installing build dependencies"
+if command -v apt-get >/dev/null 2>&1; then
+	sudo apt-get -qq update || true
+	sudo apt-get -o DPkg::Lock::Timeout=600 -qy install --no-install-recommends \
+		build-essential git curl zip unzip tar pkg-config \
+		libibverbs-dev librdmacm-dev libnuma-dev
+else
+	echo "no apt-get; ensure a C++ toolchain and libibverbs/librdmacm/libnuma -dev are installed" >&2
+fi
+
+mkdir -p "${WORK}"
+
+# Distribution CMake is routinely older than vcpkg needs. Keep the newer one in
+# the work directory and on PATH for this run only, rather than upgrading a
+# package other builds on a shared host depend on.
+host_cmake="$(cmake --version 2>/dev/null | head -1 | awk '{print $3}' || true)"
+if [ -z "${host_cmake}" ] ||
+	[ "$(printf '%s\n%s\n' "${host_cmake%.*}" "${CMAKE_MIN}" | sort -V | head -1)" != "${CMAKE_MIN}" ]; then
+	cmake_dir="${WORK}/cmake-${CMAKE_VERSION}-linux-${CUOBJ_ARCH}"
+	if [ ! -x "${cmake_dir}/bin/cmake" ]; then
+		echo ">>> cmake ${host_cmake:-none} is older than ${CMAKE_MIN}; fetching ${CMAKE_VERSION}"
+		curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CUOBJ_ARCH}.tar.gz" |
+			tar -xz -C "${WORK}"
+	fi
+	PATH="${cmake_dir}/bin:${PATH}"
+	export PATH
+fi
+echo ">>> using cmake $(cmake --version | head -1 | awk '{print $3}')"
+
+if [ ! -d "${WORK}/vcpkg" ]; then
+	git clone --depth 1 --branch "${VCPKG_REF}" https://github.com/microsoft/vcpkg "${WORK}/vcpkg"
+fi
+if [ ! -d "${WORK}/minio-cpp" ]; then
+	git clone --depth 1 --branch "${MINIO_CPP_REF}" "${MINIO_CPP_REPO}" "${WORK}/minio-cpp"
+fi
+
+echo ">>> building libminiocpp ${MINIO_CPP_REF} with RDMA"
+"${WORK}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
+cd "${WORK}/minio-cpp"
+"${WORK}/vcpkg/vcpkg" install
+cmake . -B ./build \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DBUILD_SHARED_LIBS=OFF \
+	-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+	-DCMAKE_TOOLCHAIN_FILE="${WORK}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+	-DMINIO_CPP_ENABLE_RDMA:BOOL=ON
+cmake --build ./build --config Release -j "$(nproc)"
+
+# An older install left in place would keep its stale headers first on the
+# include path, so move the whole thing aside instead of installing over it.
+if [ -e "${PREFIX}/include/miniocpp" ] || compgen -G "${PREFIX}/lib/libminiocpp.*" >/dev/null; then
+	backup="${PREFIX}/lib/warp-rdma-backup-$(date -u +%Y%m%dT%H%M%SZ)"
+	echo ">>> moving the existing libminiocpp aside to ${backup}"
+	as_root mkdir -p "${backup}"
+	[ ! -e "${PREFIX}/include/miniocpp" ] || as_root mv "${PREFIX}/include/miniocpp" "${backup}/"
+	for f in "${PREFIX}"/lib/libminiocpp.*; do
+		[ -e "${f}" ] || continue
+		as_root mv "${f}" "${backup}/"
+	done
+fi
+
+echo ">>> installing into ${PREFIX}"
+as_root cmake --install ./build
+as_root mkdir -p "${PREFIX}/lib"
+# The cuObj/cuFile libraries ship prebuilt in the checkout and have no static
+# form; libminiocpp is static, so its transitive vcpkg archives have to sit
+# beside it for the cgo link to resolve from one -L.
+as_root cp -P vendor/cuobj/lib/"${CUOBJ_ARCH}"/* "${PREFIX}/lib/"
+as_root cp -P vcpkg_installed/*/lib/*.a "${PREFIX}/lib/"
+command -v ldconfig >/dev/null 2>&1 && as_root ldconfig || true
+
+verify_prefix
+
+# Same flags .goreleaser/qreleaser.yaml composes, so a link that works here
+# works in the release.
+if command -v go >/dev/null 2>&1 && [ -f "${REPO_DIR}/go.mod" ]; then
+	echo ">>> smoke building warp with -tags=rdma"
+	cd "${REPO_DIR}"
+	CGO_ENABLED=1 \
+		CGO_CFLAGS="-I${PREFIX}/include" \
+		CGO_LDFLAGS="-L${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags $(cat "${REPO_DIR}/scripts/rdma-cgo-libs.txt")" \
+		go build -trimpath -tags=kqueue,rdma -o "${WORK}/warp-rdma-smoke" .
+	"${WORK}/warp-rdma-smoke" --version
+fi
+
+echo ">>> release host provisioned; qreleaser can build warp-rdma against ${PREFIX}"

--- a/scripts/setup-rdma-release-host.sh
+++ b/scripts/setup-rdma-release-host.sh
@@ -94,11 +94,20 @@ VCPKG_REF="${VCPKG_REF:-2026.07.29}"
 CMAKE_MIN="3.31"
 CMAKE_VERSION="${CMAKE_VERSION:-3.31.6}"
 
+run_privileged() {
+	if [ "$(id -u)" = 0 ]; then
+		"$@"
+	else
+		sudo "$@"
+	fi
+}
+
+# Writes into the prefix need privilege only when it is not already ours.
 as_root() {
 	if [ -w "${PREFIX}" ]; then
 		"$@"
 	else
-		sudo "$@"
+		run_privileged "$@"
 	fi
 }
 
@@ -145,8 +154,8 @@ fi
 
 echo ">>> installing build dependencies"
 if command -v apt-get >/dev/null 2>&1; then
-	sudo apt-get -qq update || true
-	sudo apt-get -o DPkg::Lock::Timeout=600 -qy install --no-install-recommends \
+	run_privileged apt-get -qq update || true
+	run_privileged apt-get -o DPkg::Lock::Timeout=600 -qy install --no-install-recommends \
 		build-essential git curl zip unzip tar pkg-config \
 		libibverbs-dev librdmacm-dev libnuma-dev
 else
@@ -172,11 +181,28 @@ if [ -z "${host_cmake}" ] ||
 fi
 echo ">>> using cmake $(cmake --version | head -1 | awk '{print $3}')"
 
-if [ ! -d "${WORK}/vcpkg" ]; then
-	git clone --depth 1 --branch "${VCPKG_REF}" https://github.com/microsoft/vcpkg "${WORK}/vcpkg"
-fi
-if [ ! -d "${WORK}/minio-cpp" ]; then
-	git clone --depth 1 --branch "${MINIO_CPP_REF}" "${MINIO_CPP_REPO}" "${WORK}/minio-cpp"
+# Enforce the pins on every run: a checkout left behind at an older ref is how a
+# host ends up building unpinned sources after the pin moves.
+sync_checkout() {
+	local dir="$1" repo="$2" ref="$3" before=""
+	if [ -d "${dir}/.git" ]; then
+		before="$(git -C "${dir}" rev-parse HEAD)"
+		git -C "${dir}" remote set-url origin "${repo}"
+		git -C "${dir}" fetch --depth 1 origin "${ref}"
+		git -C "${dir}" checkout --detach FETCH_HEAD
+	else
+		rm -rf "${dir}"
+		git clone --depth 1 --branch "${ref}" "${repo}" "${dir}"
+	fi
+	CHECKOUT_CHANGED=0
+	[ "${before}" = "$(git -C "${dir}" rev-parse HEAD)" ] || CHECKOUT_CHANGED=1
+}
+
+sync_checkout "${WORK}/vcpkg" https://github.com/microsoft/vcpkg "${VCPKG_REF}"
+sync_checkout "${WORK}/minio-cpp" "${MINIO_CPP_REPO}" "${MINIO_CPP_REF}"
+# Otherwise the install step copies the previous ref's archives into the prefix.
+if [ "${CHECKOUT_CHANGED}" = 1 ]; then
+	rm -rf "${WORK}/minio-cpp/build" "${WORK}/minio-cpp/vcpkg_installed"
 fi
 
 echo ">>> building libminiocpp ${MINIO_CPP_REF} with RDMA"
@@ -218,6 +244,7 @@ verify_prefix
 
 # Same flags .goreleaser/qreleaser.yaml composes, so a link that works here
 # works in the release.
+SMOKE_BUILT=0
 if command -v go >/dev/null 2>&1 && [ -f "${REPO_DIR}/go.mod" ]; then
 	echo ">>> smoke building warp with -tags=rdma"
 	cd "${REPO_DIR}"
@@ -226,6 +253,14 @@ if command -v go >/dev/null 2>&1 && [ -f "${REPO_DIR}/go.mod" ]; then
 		CGO_LDFLAGS="-L${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags $(cat "${REPO_DIR}/scripts/rdma-cgo-libs.txt")" \
 		go build -trimpath -tags=kqueue,rdma -o "${WORK}/warp-rdma-smoke" .
 	"${WORK}/warp-rdma-smoke" --version
+	SMOKE_BUILT=1
+else
+	echo ">>> WARNING: no Go toolchain or no go.mod under ${REPO_DIR}; skipped the smoke build" >&2
+	echo ">>> run --verify-only from a warp checkout to link-test before releasing" >&2
 fi
 
-echo ">>> release host provisioned; qreleaser can build warp-rdma against ${PREFIX}"
+if [ "${SMOKE_BUILT}" = 1 ]; then
+	echo ">>> release host provisioned and link-tested; qreleaser can build warp-rdma against ${PREFIX}"
+else
+	echo ">>> release host provisioned, smoke build SKIPPED; qreleaser can build warp-rdma against ${PREFIX}"
+fi

--- a/scripts/setup-rdma-release-host.sh
+++ b/scripts/setup-rdma-release-host.sh
@@ -3,34 +3,46 @@
 # Provision a release host so qreleaser can build the `warp-rdma` target.
 #
 # The RDMA build links libminiocpp through cgo, so it cannot be cross-compiled
-# and the toolchain has to exist on the release host itself -- the qreleaser
-# checkout is wiped per run, so this cannot live in the build. Run it once per
-# host (again when the pinned minio-cpp ref moves). It is idempotent.
+# from Go alone -- the C++ side has to exist on the release host for every
+# published architecture. The qreleaser checkout is wiped per run, so this cannot
+# live in the build. Run it once per host (again when the pinned minio-cpp ref
+# moves). It is idempotent.
 #
-# Installs into ${PREFIX} (default /usr/local, which is what
-# .goreleaser/qreleaser.yaml and scripts/release-post-transform.sh look for
-# when MINIOCPP_PREFIX is unset):
+# On an amd64 host this provisions two prefixes, matching the two architectures
+# .goreleaser/qreleaser.yaml publishes:
 #
-#   - libminiocpp.a built with RDMA enabled, plus its headers
-#   - the vcpkg static archives it needs to link (scripts/rdma-cgo-libs.txt)
-#   - the vendored cuObj/cuFile shared objects, which the release packaging
-#     copies out of the prefix
+#   amd64  ${PREFIX}                        (default /usr/local, built natively)
+#   arm64  ${PREFIX}/aarch64-linux-gnu      (cross-built)
 #
-# The host must already supply the RDMA stack itself -- libibverbs, librdmacm
-# and libnuma with their -dev packages -- because those are tied to its kernel
-# driver. No CUDA package is needed: CUDA is dlopened at run time.
+# Each holds libminiocpp.a built with RDMA enabled plus its headers, the vcpkg
+# static archives it links against (scripts/rdma-cgo-libs.txt), and the vendored
+# cuObj/cuFile shared objects the release packaging copies out. The arm64 prefix
+# path is fixed rather than host-dependent because qreleaser.yaml has to name it
+# in a static override.
+#
+# The host must already supply the RDMA stack itself -- libibverbs, librdmacm and
+# libnuma with their -dev packages -- because those are tied to its kernel
+# driver. Cross-building additionally needs those packages for arm64, which means
+# dpkg foreign-architecture support; scripts/rdma-cross/ holds the cmake
+# toolchain and vcpkg triplet used for it. No CUDA package is needed for either
+# architecture: CUDA is dlopened at run time.
 #
 # Usage:
-#   scripts/setup-rdma-release-host.sh [--prefix DIR] [--work DIR] [--verify-only]
+#   scripts/setup-rdma-release-host.sh [--prefix DIR] [--work DIR]
+#                                      [--no-cross] [--verify-only]
 #
-# Any existing libminiocpp in the prefix is moved aside to a timestamped
-# backup directory rather than overwritten.
+#   --no-cross     provision only the host architecture
+#   --verify-only  check the existing prefixes and exit
+#
+# Any existing libminiocpp in a prefix is moved aside to a timestamped backup
+# directory rather than overwritten.
 
 set -euo pipefail
 
 PREFIX="${PREFIX:-/usr/local}"
 WORK="${WORK:-${HOME}/.warp-rdma-host}"
 VERIFY_ONLY=0
+CROSS=1
 
 need_value() {
 	[ $# -ge 2 ] || {
@@ -51,11 +63,14 @@ while [ $# -gt 0 ]; do
 		WORK="$2"
 		shift
 		;;
+	--no-cross)
+		CROSS=0
+		;;
 	--verify-only)
 		VERIFY_ONLY=1
 		;;
 	-h | --help)
-		sed -n '2,25p' "$0"
+		sed -n '2,42p' "$0"
 		exit 0
 		;;
 	*)
@@ -67,6 +82,7 @@ while [ $# -gt 0 ]; do
 done
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CROSS_DIR="${REPO_DIR}/scripts/rdma-cross"
 
 case "$(uname -s)" in
 Linux) ;;
@@ -77,8 +93,8 @@ Linux) ;;
 esac
 
 case "$(uname -m)" in
-x86_64) CUOBJ_ARCH=x86_64 ;;
-aarch64 | arm64) CUOBJ_ARCH=aarch64 ;;
+x86_64) HOST_ARCH=amd64 ;;
+aarch64 | arm64) HOST_ARCH=arm64 ;;
 *)
 	echo "unsupported architecture: $(uname -m) (RDMA builds are linux/amd64 and linux/arm64 only)" >&2
 	exit 1
@@ -94,6 +110,77 @@ VCPKG_REF="${VCPKG_REF:-2026.07.29}"
 CMAKE_MIN="3.31"
 CMAKE_VERSION="${CMAKE_VERSION:-3.31.6}"
 
+TARGETS=("${HOST_ARCH}")
+if [ "${CROSS}" = 1 ]; then
+	if [ "${HOST_ARCH}" = amd64 ]; then
+		TARGETS+=(arm64)
+	else
+		echo ">>> cross-building amd64 from ${HOST_ARCH} is not supported; provisioning ${HOST_ARCH} only" >&2
+	fi
+fi
+
+arch_prefix() {
+	case "$1" in
+	# Kept at the bare prefix so an amd64-only host stays provisioned exactly as
+	# it was before arm64 was published.
+	amd64) echo "${PREFIX}" ;;
+	arm64) echo "${PREFIX}/aarch64-linux-gnu" ;;
+	esac
+}
+
+arch_cuobj() {
+	case "$1" in
+	amd64) echo x86_64 ;;
+	arm64) echo aarch64 ;;
+	esac
+}
+
+arch_triplet() {
+	case "$1" in
+	amd64) echo x64-linux ;;
+	arm64) echo arm64-linux ;;
+	esac
+}
+
+# What readelf reports for a correctly-targeted object, so a prefix full of
+# host-architecture archives cannot pass verification. readelf rather than
+# objdump: objdump only knows its own target and calls everything else UNKNOWN!,
+# which would fail every cross prefix.
+arch_machine() {
+	case "$1" in
+	amd64) echo "Advanced Micro Devices X86-64" ;;
+	arm64) echo "AArch64" ;;
+	esac
+}
+
+# Reads the ELF machine of an object, an archive member or an executable.
+elf_machine() {
+	readelf -h "$1" 2>/dev/null | sed -n 's/^ *Machine: *//p' | head -1
+}
+
+# scripts/rdma-cgo-libs.txt names three kinds of library: the toolchain's own,
+# the cuObj vendor shared objects that cannot be static, and everything else,
+# which must come from an archive. A published binary that picks one of the last
+# group up dynamically has a runtime dependency the package neither declares nor
+# bundles, and fails to start on a customer host.
+static_libs() {
+	local lib
+	for lib in $(tr ' ' '\n' <"${REPO_DIR}/scripts/rdma-cgo-libs.txt" | sed -n 's/^-l//p'); do
+		case "${lib}" in
+		stdc++ | m | dl | pthread) ;;
+		cuobjclient | cufile | cufile_rdma) ;;
+		*) echo "${lib}" ;;
+		esac
+	done
+}
+
+arch_cc() {
+	case "$1" in
+	arm64) [ "${HOST_ARCH}" = arm64 ] && echo gcc || echo aarch64-linux-gnu-gcc ;;
+	amd64) [ "${HOST_ARCH}" = amd64 ] && echo gcc || echo x86_64-linux-gnu-gcc ;;
+	esac
+}
+
 run_privileged() {
 	if [ "$(id -u)" = 0 ]; then
 		"$@"
@@ -102,7 +189,8 @@ run_privileged() {
 	fi
 }
 
-# Writes into the prefix need privilege only when it is not already ours.
+# Writes into the prefix need privilege only when it is not already ours. Every
+# per-architecture prefix lives under PREFIX, so its writability decides for all.
 as_root() {
 	if [ -w "${PREFIX}" ]; then
 		"$@"
@@ -111,46 +199,67 @@ as_root() {
 	fi
 }
 
-# Assert the prefix can satisfy the exact link line qreleaser composes, so a
-# half-provisioned host fails here in seconds instead of 20 minutes into a
-# release.
+# Assert a prefix can satisfy the exact link line qreleaser composes for one
+# architecture, so a half-provisioned or wrong-architecture host fails here in
+# seconds instead of 20 minutes into a release.
 verify_prefix() {
-	local missing=0 lib name
+	local arch="$1"
+	local prefix machine missing=0 lib name found
+	prefix="$(arch_prefix "${arch}")"
+	machine="$(arch_machine "${arch}")"
 
-	if [ ! -f "${PREFIX}/include/miniocpp/c_api.h" ]; then
-		echo "MISSING: ${PREFIX}/include/miniocpp/c_api.h (libminiocpp too old for the minio-go revision in go.mod)" >&2
+	if [ ! -f "${prefix}/include/miniocpp/c_api.h" ]; then
+		echo "MISSING: ${prefix}/include/miniocpp/c_api.h (libminiocpp too old for the minio-go revision in go.mod)" >&2
 		missing=1
 	fi
 
-	for lib in $(tr ' ' '\n' <"${REPO_DIR}/scripts/rdma-cgo-libs.txt" | sed -n 's/^-l//p'); do
-		case "${lib}" in
-		# Supplied by the toolchain and the host RDMA stack, not the prefix.
-		stdc++ | m | dl | pthread) continue ;;
-		esac
+	for lib in $(static_libs); do
 		name="lib${lib}"
-		if ! compgen -G "${PREFIX}/lib/${name}.a" >/dev/null &&
-			! compgen -G "${PREFIX}/lib/${name}.so*" >/dev/null; then
-			echo "MISSING: ${PREFIX}/lib/${name}.{a,so}" >&2
+		if ! compgen -G "${prefix}/lib/${name}.a" >/dev/null; then
+			echo "MISSING: ${prefix}/lib/${name}.a (${arch})" >&2
+			missing=1
+		fi
+		# ld prefers a shared object over an archive in the same -L, so one left
+		# here by an older install silently changes how the release links.
+		if compgen -G "${prefix}/lib/${name}.so*" >/dev/null; then
+			echo "SHADOWED: ${prefix}/lib/${name}.so* would be linked instead of ${name}.a (${arch})" >&2
 			missing=1
 		fi
 	done
 
 	# scripts/release-post-transform.sh copies these out of the prefix by name.
 	for name in libcuobjclient.so libcufile.so libcufile_rdma.so; do
-		if ! compgen -G "${PREFIX}/lib/${name}*" >/dev/null; then
-			echo "MISSING: ${PREFIX}/lib/${name}* (needed by release packaging)" >&2
+		if ! compgen -G "${prefix}/lib/${name}*" >/dev/null; then
+			echo "MISSING: ${prefix}/lib/${name}* (${arch}, needed by release packaging)" >&2
+			missing=1
+		fi
+	done
+
+	# Name checks alone cannot tell a cross prefix from one holding host-built
+	# archives, which is the failure a shared vcpkg checkout invites. Check both
+	# libminiocpp and a vcpkg archive, since they are produced by separate builds.
+	for name in libminiocpp.a libssl.a; do
+		[ -f "${prefix}/lib/${name}" ] || continue
+		found="$(elf_machine "${prefix}/lib/${name}")"
+		if [ "${found}" != "${machine}" ]; then
+			echo "WRONG ARCH: ${prefix}/lib/${name} is '${found}', expected '${machine}' for ${arch}" >&2
 			missing=1
 		fi
 	done
 
 	[ "${missing}" = 0 ] || return 1
-	echo ">>> ${PREFIX} satisfies the RDMA link line"
+	echo ">>> ${prefix} satisfies the RDMA link line for ${arch}"
 }
 
 if [ "${VERIFY_ONLY}" = 1 ]; then
-	verify_prefix
-	exit 0
+	rc=0
+	for arch in "${TARGETS[@]}"; do
+		verify_prefix "${arch}" || rc=1
+	done
+	exit "${rc}"
 fi
+
+echo ">>> provisioning for: ${TARGETS[*]}"
 
 echo ">>> installing build dependencies"
 if command -v apt-get >/dev/null 2>&1; then
@@ -158,6 +267,26 @@ if command -v apt-get >/dev/null 2>&1; then
 	run_privileged apt-get -o DPkg::Lock::Timeout=600 -qy install --no-install-recommends \
 		build-essential git curl zip unzip tar pkg-config \
 		libibverbs-dev librdmacm-dev libnuma-dev
+
+	if printf '%s\n' "${TARGETS[@]}" | grep -qx arm64 && [ "${HOST_ARCH}" != arm64 ]; then
+		echo ">>> installing the aarch64 cross toolchain and arm64 RDMA libraries"
+		run_privileged dpkg --add-architecture arm64
+		# The amd64 archive carries no arm64 packages; they live on ports.ubuntu.com.
+		# Its arm64 index then 404s harmlessly, so update stays tolerant.
+		if [ ! -f /etc/apt/sources.list.d/arm64-ports.list ]; then
+			codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+			printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s main universe\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-updates main universe\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports %s-security main universe\n' \
+				"${codename}" "${codename}" "${codename}" |
+				run_privileged tee /etc/apt/sources.list.d/arm64-ports.list >/dev/null
+		fi
+		run_privileged apt-get -qq update || true
+		# libibverbs-dev and friends are Multi-Arch: same -- install both arches
+		# together so adding :arm64 cannot drop :amd64 and break native builds.
+		run_privileged apt-get -o DPkg::Lock::Timeout=600 -qy install --no-install-recommends \
+			gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+			libibverbs-dev:amd64 librdmacm-dev:amd64 libnuma-dev:amd64 \
+			libibverbs-dev:arm64 librdmacm-dev:arm64 libnuma-dev:arm64
+	fi
 else
 	echo "no apt-get; ensure a C++ toolchain and libibverbs/librdmacm/libnuma -dev are installed" >&2
 fi
@@ -170,10 +299,10 @@ mkdir -p "${WORK}"
 host_cmake="$(cmake --version 2>/dev/null | head -1 | awk '{print $3}' || true)"
 if [ -z "${host_cmake}" ] ||
 	[ "$(printf '%s\n%s\n' "${host_cmake%.*}" "${CMAKE_MIN}" | sort -V | head -1)" != "${CMAKE_MIN}" ]; then
-	cmake_dir="${WORK}/cmake-${CMAKE_VERSION}-linux-${CUOBJ_ARCH}"
+	cmake_dir="${WORK}/cmake-${CMAKE_VERSION}-linux-$(arch_cuobj "${HOST_ARCH}")"
 	if [ ! -x "${cmake_dir}/bin/cmake" ]; then
 		echo ">>> cmake ${host_cmake:-none} is older than ${CMAKE_MIN}; fetching ${CMAKE_VERSION}"
-		curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CUOBJ_ARCH}.tar.gz" |
+		curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(arch_cuobj "${HOST_ARCH}").tar.gz" |
 			tar -xz -C "${WORK}"
 	fi
 	PATH="${cmake_dir}/bin:${PATH}"
@@ -199,60 +328,166 @@ sync_checkout() {
 }
 
 sync_checkout "${WORK}/vcpkg" https://github.com/microsoft/vcpkg "${VCPKG_REF}"
-sync_checkout "${WORK}/minio-cpp" "${MINIO_CPP_REPO}" "${MINIO_CPP_REF}"
-# Otherwise the install step copies the previous ref's archives into the prefix.
-if [ "${CHECKOUT_CHANGED}" = 1 ]; then
-	rm -rf "${WORK}/minio-cpp/build" "${WORK}/minio-cpp/vcpkg_installed"
-fi
-
-echo ">>> building libminiocpp ${MINIO_CPP_REF} with RDMA"
 "${WORK}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-cd "${WORK}/minio-cpp"
-"${WORK}/vcpkg/vcpkg" install
-cmake . -B ./build \
-	-DCMAKE_BUILD_TYPE=Release \
-	-DBUILD_SHARED_LIBS=OFF \
-	-DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-	-DCMAKE_TOOLCHAIN_FILE="${WORK}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
-	-DMINIO_CPP_ENABLE_RDMA:BOOL=ON
-cmake --build ./build --config Release -j "$(nproc)"
 
-# An older install left in place would keep its stale headers first on the
-# include path, so move the whole thing aside instead of installing over it.
-if [ -e "${PREFIX}/include/miniocpp" ] || compgen -G "${PREFIX}/lib/libminiocpp.*" >/dev/null; then
-	backup="${PREFIX}/lib/warp-rdma-backup-$(date -u +%Y%m%dT%H%M%SZ)"
-	echo ">>> moving the existing libminiocpp aside to ${backup}"
-	as_root mkdir -p "${backup}"
-	[ ! -e "${PREFIX}/include/miniocpp" ] || as_root mv "${PREFIX}/include/miniocpp" "${backup}/"
-	for f in "${PREFIX}"/lib/libminiocpp.*; do
-		[ -e "${f}" ] || continue
-		as_root mv "${f}" "${backup}/"
+# One checkout per architecture. Sharing one would put two triplets' artifacts in
+# the same vcpkg_installed and build tree, and the install step copies archives
+# out of there by glob.
+build_target() {
+	local arch="$1"
+	local src prefix triplet cuobj vcpkg_args=() cmake_args=()
+	src="${WORK}/minio-cpp-${arch}"
+	prefix="$(arch_prefix "${arch}")"
+	triplet="$(arch_triplet "${arch}")"
+	cuobj="$(arch_cuobj "${arch}")"
+
+	sync_checkout "${src}" "${MINIO_CPP_REPO}" "${MINIO_CPP_REF}"
+	# Otherwise the install step copies the previous ref's artifacts into the prefix.
+	if [ "${CHECKOUT_CHANGED}" = 1 ]; then
+		rm -rf "${src}/build" "${src}/vcpkg_installed"
+	fi
+
+	# A CMakeCache holding a different absolute source path -- a work directory
+	# that moved -- makes cmake refuse to configure at all.
+	if [ -f "${src}/build/CMakeCache.txt" ] &&
+		! grep -qx "CMAKE_HOME_DIRECTORY:INTERNAL=${src}" "${src}/build/CMakeCache.txt"; then
+		echo ">>> dropping a stale ${arch} build directory from a previous path"
+		rm -rf "${src}/build"
+	fi
+
+	if [ "${arch}" != "${HOST_ARCH}" ]; then
+		vcpkg_args+=(--overlay-triplets="${CROSS_DIR}/triplets")
+		cmake_args+=(
+			-DVCPKG_OVERLAY_TRIPLETS="${CROSS_DIR}/triplets"
+			-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE="${CROSS_DIR}/aarch64-linux-gnu.cmake"
+		)
+	fi
+
+	echo ">>> building libminiocpp ${MINIO_CPP_REF} with RDMA for ${arch} (${triplet})"
+	cd "${src}"
+	# --host-triplet keeps vcpkg's own build tools native while the port tree is
+	# built for the target.
+	"${WORK}/vcpkg/vcpkg" install \
+		--triplet "${triplet}" \
+		--host-triplet "$(arch_triplet "${HOST_ARCH}")" \
+		"${vcpkg_args[@]}"
+
+	cmake . -B ./build \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIBS=OFF \
+		-DCMAKE_INSTALL_PREFIX="${prefix}" \
+		-DCMAKE_TOOLCHAIN_FILE="${WORK}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+		-DVCPKG_TARGET_TRIPLET="${triplet}" \
+		-DMINIO_CPP_ENABLE_RDMA:BOOL=ON \
+		"${cmake_args[@]}"
+	cmake --build ./build --config Release -j "$(nproc)"
+
+	# An older install left in place would keep its stale headers first on the
+	# include path, so move the whole thing aside instead of installing over it.
+	# An install this run would reproduce byte for byte is not older, and backing
+	# it up on every rerun would litter the prefix.
+	local stale=() f lib
+	if cmp -s "${src}/build/libminiocpp.a" "${prefix}/lib/libminiocpp.a"; then
+		echo ">>> ${prefix} already holds this ${arch} build"
+	else
+		if [ -e "${prefix}/include/miniocpp" ]; then
+			stale+=("${prefix}/include/miniocpp")
+		fi
+		for f in "${prefix}"/lib/libminiocpp.*; do
+			if [ -e "${f}" ]; then
+				stale+=("${f}")
+			fi
+		done
+	fi
+
+	# Shared objects that shadow the archives we install. ld picks these over the
+	# .a in the same -L, which is how a release ends up depending on a library it
+	# neither bundles nor declares.
+	for lib in $(static_libs); do
+		for f in "${prefix}"/lib/"lib${lib}".so*; do
+			if [ -e "${f}" ]; then
+				stale+=("${f}")
+			fi
+		done
 	done
-fi
 
-echo ">>> installing into ${PREFIX}"
-as_root cmake --install ./build
-as_root mkdir -p "${PREFIX}/lib"
-# The cuObj/cuFile libraries ship prebuilt in the checkout and have no static
-# form; libminiocpp is static, so its transitive vcpkg archives have to sit
-# beside it for the cgo link to resolve from one -L.
-as_root cp -P vendor/cuobj/lib/"${CUOBJ_ARCH}"/* "${PREFIX}/lib/"
-as_root cp -P vcpkg_installed/*/lib/*.a "${PREFIX}/lib/"
-command -v ldconfig >/dev/null 2>&1 && as_root ldconfig || true
+	if [ "${#stale[@]}" -gt 0 ]; then
+		local backup="${prefix}/lib/warp-rdma-backup-$(date -u +%Y%m%dT%H%M%SZ)"
+		echo ">>> moving ${#stale[@]} stale ${arch} file(s) aside to ${backup}"
+		as_root mkdir -p "${backup}"
+		for f in "${stale[@]}"; do
+			as_root mv "${f}" "${backup}/"
+		done
+	fi
 
-verify_prefix
+	echo ">>> installing ${arch} into ${prefix}"
+	as_root cmake --install ./build
+	as_root mkdir -p "${prefix}/lib"
+	# The cuObj/cuFile libraries ship prebuilt in the checkout and have no static
+	# form; libminiocpp is static, so its transitive vcpkg archives have to sit
+	# beside it for the cgo link to resolve from one -L. The triplet is named
+	# explicitly so a stray second triplet directory cannot be picked up.
+	as_root cp -P vendor/cuobj/lib/"${cuobj}"/* "${prefix}/lib/"
+	as_root cp -P vcpkg_installed/"${triplet}"/lib/*.a "${prefix}/lib/"
+	command -v ldconfig >/dev/null 2>&1 && as_root ldconfig || true
 
-# Same flags .goreleaser/qreleaser.yaml composes, so a link that works here
-# works in the release.
-SMOKE_BUILT=0
-if command -v go >/dev/null 2>&1 && [ -f "${REPO_DIR}/go.mod" ]; then
-	echo ">>> smoke building warp with -tags=rdma"
+	verify_prefix "${arch}"
+}
+
+# Cross-built objects cannot be executed on the host, so the smoke build proves
+# the link and the ELF target instead of running --version.
+smoke_build() {
+	local arch="$1"
+	local prefix out
+	prefix="$(arch_prefix "${arch}")"
+	out="${WORK}/warp-rdma-smoke-${arch}"
+
+	echo ">>> smoke building warp with -tags=rdma for ${arch}"
 	cd "${REPO_DIR}"
 	CGO_ENABLED=1 \
-		CGO_CFLAGS="-I${PREFIX}/include" \
-		CGO_LDFLAGS="-L${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags $(cat "${REPO_DIR}/scripts/rdma-cgo-libs.txt")" \
-		go build -trimpath -tags=kqueue,rdma -o "${WORK}/warp-rdma-smoke" .
-	"${WORK}/warp-rdma-smoke" --version
+		GOOS=linux GOARCH="${arch}" \
+		CC="$(arch_cc "${arch}")" \
+		CGO_CFLAGS="-I${prefix}/include" \
+		CGO_LDFLAGS="-L${prefix}/lib -Wl,-rpath-link,${prefix}/lib -Wl,-rpath,/usr/lib/warp -Wl,--enable-new-dtags $(cat "${REPO_DIR}/scripts/rdma-cgo-libs.txt")" \
+		go build -trimpath -tags=kqueue,rdma -o "${out}" .
+
+	local machine
+	machine="$(elf_machine "${out}")"
+	if [ "${machine}" != "$(arch_machine "${arch}")" ]; then
+		echo "smoke build produced '${machine}', expected '$(arch_machine "${arch}")'" >&2
+		return 1
+	fi
+	readelf -d "${out}" | grep -q '/usr/lib/warp' || {
+		echo "smoke build is missing the /usr/lib/warp runpath" >&2
+		return 1
+	}
+
+	# The published binary may only need the cuObj libraries it ships and the base
+	# C/C++ runtime. Anything else here is a dependency the package does not
+	# declare, so the binary would fail to start on a customer host.
+	local needed lib
+	needed="$(readelf -d "${out}" | sed -n 's/.*Shared library: \[\(.*\)\]/\1/p')"
+	for lib in $(static_libs); do
+		if printf '%s\n' "${needed}" | grep -q "^lib${lib}\.so"; then
+			echo "smoke build links lib${lib} dynamically; something in $(arch_prefix "${arch}")/lib shadows lib${lib}.a" >&2
+			return 1
+		fi
+	done
+	echo ">>> ${arch} smoke build links and targets ${machine}"
+
+	[ "${arch}" = "${HOST_ARCH}" ] || return 0
+	"${out}" --version
+}
+
+for arch in "${TARGETS[@]}"; do
+	build_target "${arch}"
+done
+
+SMOKE_BUILT=0
+if command -v go >/dev/null 2>&1 && [ -f "${REPO_DIR}/go.mod" ]; then
+	for arch in "${TARGETS[@]}"; do
+		smoke_build "${arch}"
+	done
 	SMOKE_BUILT=1
 else
 	echo ">>> WARNING: no Go toolchain or no go.mod under ${REPO_DIR}; skipped the smoke build" >&2
@@ -260,7 +495,7 @@ else
 fi
 
 if [ "${SMOKE_BUILT}" = 1 ]; then
-	echo ">>> release host provisioned and link-tested; qreleaser can build warp-rdma against ${PREFIX}"
+	echo ">>> release host provisioned and link-tested for: ${TARGETS[*]}"
 else
-	echo ">>> release host provisioned, smoke build SKIPPED; qreleaser can build warp-rdma against ${PREFIX}"
+	echo ">>> release host provisioned for: ${TARGETS[*]}, smoke build SKIPPED"
 fi


### PR DESCRIPTION
Two related changes to the S3-over-RDMA release path: make the release host's toolchain reproducible, and publish `warp-rdma` for arm64 as well as amd64.

## 1. Release-host provisioning

The `warp-rdma` build links libminiocpp through cgo, so the C++ toolchain has to exist on the release host — the qreleaser checkout is wiped per run, so it cannot be provisioned from the build. `.goreleaser/qreleaser.yaml` documented that requirement in a comment, but nothing installed or verified it.

That gap broke the v1.6.0 release: the host carried a pre-`c_api.h` libminiocpp (v0.3.0 era, installed for something else), and the release died 20 minutes in with

```
rdma.go:17:11: fatal error: miniocpp/c_api.h: No such file or directory
```

Two more failures were queued behind it — `/usr/local/lib` had 2 of the 9 archives `scripts/rdma-cgo-libs.txt` names, and none of the cuObj shared objects `scripts/release-post-transform.sh` copies out of the prefix under `set -euo pipefail`.

`scripts/setup-rdma-release-host.sh` provisions and verifies a host: pinned minio-cpp and vcpkg refs in lockstep with `build-rdma.sh` and `go-rdma.yml`, enforced on every run; an existing install moved aside to a timestamped backup rather than overwritten; a new-enough CMake kept in its own work directory instead of upgrading a package other builds on a shared host depend on. `--verify-only` asserts the prefix can satisfy the exact link line qreleaser composes, which is cheap enough to use as a release preflight and would have turned this into a 2-second failure.

## 2. arm64

The RDMA build needs the C++ side built for every architecture it publishes, so arm64 is cross-built on the amd64 release host — which already had the aarch64 toolchain and arm64 RDMA libraries provisioned for the minio server's RDMA build.

- `scripts/rdma-cross/` — cmake toolchain and vcpkg overlay triplet. minio-cpp already selects its vendored cuObj libraries from `CMAKE_SYSTEM_PROCESSOR`, so the aarch64 ones resolve without patching it.
- one prefix per architecture: amd64 natively at the prefix, arm64 at `<prefix>/aarch64-linux-gnu`. Verification uses `readelf` to confirm a prefix and a smoke build really target the architecture they claim — the check that separates a working cross prefix from one holding host archives.
- `qreleaser.yaml` gains arm64 through a goreleaser `overrides` entry rather than `{{ .Arch }}` templating, so the amd64 link line stays byte for byte what it was.
- `release-post-transform.sh` packages the cuObj libraries from the prefix matching the architecture being packaged.

## A live bug this turned up

Enforcing static linkage surfaced a defect predating this PR. A `libcurlpp.so` dated Nov 2024, left in `/usr/local/lib` by an unrelated install, shadowed the `libcurlpp.a` beside it — `ld` prefers a shared object over an archive in the same `-L`. The amd64 `warp.rdma` therefore carried `NEEDED libcurlpp.so.1`, a runtime dependency the package neither bundles nor declares, and would not have started on a host without libcurlpp. arm64 was unaffected; its prefix was clean.

Shadowing shared objects are now moved aside with stale headers, `verify_prefix` rejects them, and the smoke build fails if the binary picks one up dynamically.

## Testing

On the actual release host:

- both prefixes provisioned and verified; `readelf` confirms AArch64 archives in the arm64 prefix, X86-64 in the amd64 one
- `goreleaser build --id warp-rdma` produces both binaries; the arm64 one is `ELF 64-bit LSB executable, ARM aarch64` with `RUNPATH [/usr/lib/warp]`
- after the shadowing fix both binaries need exactly `libcuobjclient.so.1`, `libcufile.so.0` and the base C/C++ runtime
- `release-post-transform.sh` packages both arches; unpacking the arm64 deb confirms the binary *and* the bundled `libcuobjclient.so.1.2.0` are AArch64
- reruns are idempotent: unchanged refs leave build directories intact, a moved ref is detected and its stale artifacts dropped, and an install identical to what is already there is left in place

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Linux host setup for RDMA-enabled release builds.
  * Added configurable installation paths, cross-compilation, verification checks, and optional smoke testing.
  * Added architecture-aware tooling, libraries, and packaging for Linux amd64 and arm64.
  * Safely preserves existing installations during setup.

* **Documentation**
  * Updated build and installation guidance with arm64 requirements and package names.
  * Documented separate native and cross-compilation configurations and behavior on unprovisioned hosts.

* **Bug Fixes**
  * Improved release packaging to select the correct architecture-specific libraries and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->