### PR TITLE
build(rdma): move the minio-cpp pin to the pre-flight rail-marking fix

### DIFF
--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: minio/minio-cpp
-          ref: 1fc511519a6f9ff55420d25cdf14b1ab3f764690
+          ref: f89cc4d25d30057f30a0c3adabe2244c9e222486
           path: "minio-cpp"
           persist-credentials: false
 

--- a/scripts/build-rdma.sh
+++ b/scripts/build-rdma.sh
@@ -126,7 +126,7 @@ else
 		"${MINIO_CPP_REPO:-https://github.com/minio/minio-cpp}"
 fi
 git -C "${MINIO_CPP_DIR}" fetch --depth 1 origin \
-	"${MINIO_CPP_REF:-1fc511519a6f9ff55420d25cdf14b1ab3f764690}"
+	"${MINIO_CPP_REF:-f89cc4d25d30057f30a0c3adabe2244c9e222486}"
 git -C "${MINIO_CPP_DIR}" checkout --detach -f FETCH_HEAD
 
 echo ">>> building libminiocpp with RDMA"

--- a/scripts/setup-rdma-release-host.sh
+++ b/scripts/setup-rdma-release-host.sh
@@ -106,7 +106,7 @@ esac
 # minio-go revision in go.mod, and vcpkg's port scripts track the newest CMake.
 # A commit, not a tag: the RDMA transport moved to libs3rdma after v0.5.0 and
 # no release carries it yet. Move this to the tag once one does.
-MINIO_CPP_REF="${MINIO_CPP_REF:-1fc511519a6f9ff55420d25cdf14b1ab3f764690}"
+MINIO_CPP_REF="${MINIO_CPP_REF:-f89cc4d25d30057f30a0c3adabe2244c9e222486}"
 MINIO_CPP_REPO="${MINIO_CPP_REPO:-https://github.com/minio/minio-cpp}"
 VCPKG_REF="${VCPKG_REF:-2026.07.29}"
 CMAKE_MIN="3.31"


### PR DESCRIPTION
Moves the minio-cpp pin from `1fc5115` to [`f89cc4d`](https://github.com/minio/minio-cpp/commit/f89cc4d25d30057f30a0c3adabe2244c9e222486) in all three places that build it:

- `scripts/build-rdma.sh`
- `scripts/setup-rdma-release-host.sh`
- `.github/workflows/go-rdma.yml`

## What it picks up

**[minio-cpp#252](https://github.com/minio/minio-cpp/pull/252)** — a request that never left the client (a `partNumber` outside `1..10000`, a URL that will not build, a zero-length ranged GET) was being charged to the rail its token named. That marked healthy hardware unusable over a bad argument, and the retry marked a second rail too; on a two-rail host it took the client to zero usable rails.

**[miniohq/s3rdma#24](https://github.com/miniohq/s3rdma/pull/24)**, via minio-cpp's vendored copy — `pin` registered a buffer on every rail while a transfer names one. Register+deregister of a 4 MiB buffer went from 241.5 µs to 114.5 µs across two rails.

warp links libminiocpp **statically** but bundles libs3rdma as a shared object into the tarball and the `.deb`/`.rpm`/`.apk`, so **this pin is the only thing deciding which library ships to users**.

## Verification

Not just a SHA edit — rebuilt and run on a two-rail mlx5 host:

- minio-cpp rebuilt at `f89cc4d`, libminiocpp + libs3rdma installed
- warp rebuilt with `-tags=rdma`; `ldd` resolves `libs3rdma.so.0` to the new build
- `warp put --rdma=cpu` across a 4-node cluster: **6887 MiB/s, 1722 obj/s**, avg 9.3 ms

## Follow-up for whoever cuts the next RDMA release

`scripts/setup-rdma-release-host.sh` must be re-run on the release host before the next RDMA release — its own header says so whenever this pin moves. Otherwise the release builds against the previous prefix and silently ships the old library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the RDMA build and release setup to use a newer MinIO C++ revision.
  * Aligned automated RDMA workflow builds with the updated revision for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->