### PR TITLE
feat(rdma): pre-allocate the pinned buffer pool, and carry objects past 4 GiB

### DIFF
--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: minio/minio-cpp
-          ref: f89cc4d25d30057f30a0c3adabe2244c9e222486
+          ref: edba72c940b5372afb60817bb5a14124b572135b
           path: "minio-cpp"
           persist-credentials: false
 

--- a/.github/workflows/go-rdma.yml
+++ b/.github/workflows/go-rdma.yml
@@ -36,13 +36,12 @@ jobs:
       # Pinned in lockstep with scripts/build-rdma.sh and
       # scripts/setup-rdma-release-host.sh: this job copies vendor/s3rdma out of
       # the checkout, so a floating main makes the build race whatever landed
-      # there. A commit rather than a tag -- the RDMA transport moved to
-      # libs3rdma after v0.5.0 and no release carries it yet.
+      # there. v0.6.0 is the first release carrying the libs3rdma transport.
       - name: Checkout minio-cpp
         uses: actions/checkout@v5
         with:
           repository: minio/minio-cpp
-          ref: edba72c940b5372afb60817bb5a14124b572135b
+          ref: v0.6.0
           path: "minio-cpp"
           persist-credentials: false
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -189,6 +189,12 @@ var ioFlags = []cli.Flag{
 		Value:  "",
 	},
 	cli.StringFlag{
+		Name:   "rdma.window",
+		Usage:  "Stage RDMA PUTs through a pinned window of this size instead of pinning the whole object, e.g. \"64MiB\". Objects upload as multipart, so the ETag gains a -N suffix. Empty pins the whole object.",
+		EnvVar: appNameUC + "_RDMA_WINDOW",
+		Value:  "",
+	},
+	cli.StringFlag{
 		Name:   "region",
 		Usage:  "Specify a custom region",
 		EnvVar: appNameUC + "_REGION",
@@ -348,6 +354,14 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 	noOps := ctx.Bool("stress")
 
 	rdmaMode := ctx.String("rdma")
+	var rdmaWindow int64
+	if w := ctx.String("rdma.window"); w != "" {
+		sz, err := toSize(w)
+		if err != nil {
+			console.Fatalf("error parsing --rdma.window: %v\n", err)
+		}
+		rdmaWindow = int64(sz)
+	}
 	switch rdmaMode {
 	case bench.RDMAModeOff:
 	case bench.RDMAModeCPU:
@@ -394,6 +408,8 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 		Location:      ctx.String("region"),
 		PutOpts:       putOpts,
 		RDMAMode:      rdmaMode,
+		RDMAWindow:    rdmaWindow,
+		ObjSize:       objSize(ctx),
 		DiscardOutput: noOps,
 		ExtraOut:      extra,
 		RpsLimiter:    rpsLimiter,

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -19,6 +19,7 @@ package cli
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -359,6 +360,12 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 		sz, err := toSize(w)
 		if err != nil {
 			console.Fatalf("error parsing --rdma.window: %v\n", err)
+		}
+		// toSize returns uint64; anything past MaxInt64 would wrap negative,
+		// and a negative window reads as "not set" -- silently ignoring what
+		// was asked for rather than rejecting it.
+		if sz > math.MaxInt64 {
+			console.Fatalf("--rdma.window %s is too large\n", w)
 		}
 		rdmaWindow = int64(sz)
 	}

--- a/cli/generator.go
+++ b/cli/generator.go
@@ -104,3 +104,27 @@ func newGenSource(ctx *cli.Context, sizeField string) func() generator.Source {
 func toSize(size string) (uint64, error) {
 	return humanize.ParseBytes(size)
 }
+
+// objSize reports the largest object the generator may produce, so a buffer
+// pool can be sized before the run. Ranges and histograms report their upper
+// bound: a pool sized to the largest object never has to grow mid-run, which
+// is the whole point of allocating it up front. Returns 0 when the size cannot
+// be determined, leaving the caller to fall back.
+func objSize(ctx *cli.Context) int64 {
+	field := "obj.size"
+	if !ctx.IsSet(field) && ctx.String(field) == "" {
+		return 0
+	}
+	tokens := strings.Split(ctx.String(field), ",")
+	var largest int64
+	for _, t := range tokens {
+		sz, err := toSize(strings.TrimSpace(t))
+		if err != nil {
+			return 0
+		}
+		if int64(sz) > largest {
+			largest = int64(sz)
+		}
+	}
+	return largest
+}

--- a/pkg/bench/benchmark.go
+++ b/pkg/bench/benchmark.go
@@ -59,6 +59,18 @@ type Common struct {
 	// at build time) and lets the NIC GPU-Direct RDMA into it.
 	RDMAMode string
 
+	// ObjSize is the nominal object size the generator was configured with.
+	// It exists so the RDMA buffer pool can be sized before the run rather
+	// than growing inside it; the generator remains the authority on the size
+	// of any individual object.
+	ObjSize int64
+
+	// RDMAWindow, when non-zero, stages a PUT through a pinned buffer of this
+	// size rather than pinning the whole object. minio-go then streams it as
+	// an RDMA multipart upload, so pinned memory is one part rather than one
+	// object and objects past the 4 GiB an RDMA descriptor can address work.
+	RDMAWindow int64
+
 	PrepareProgress chan float64
 
 	// Custom is returned to server if set by clients.

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -68,7 +68,14 @@ func (u *Put) Prepare(ctx context.Context) error {
 	if err := u.prepareRDMAPool(); err != nil {
 		return err
 	}
-	return u.createEmptyBucket(ctx)
+	if err := u.createEmptyBucket(ctx); err != nil {
+		// A failed Prepare returns without the runner calling Cleanup, so the
+		// pool allocated above would stay pinned for the life of the process.
+		u.rdmaPool.Free()
+		u.rdmaPool = nil
+		return err
+	}
+	return nil
 }
 
 // prepareRDMAPool sizes and allocates the pinned buffers before the run.
@@ -111,9 +118,6 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 	}
 	u.prefixes = make(map[string]struct{}, u.Concurrency)
 
-	// Non-terminating context.
-	nonTerm := context.Background()
-
 	for i := 0; i < u.Concurrency; i++ {
 		src := u.Source()
 		u.prefixes[src.Prefix()] = struct{}{}
@@ -151,6 +155,16 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 			// every worker for a page-aligned allocation and the ibv_reg_mr
 			// that pins it -- work unrelated to the transfer being measured.
 			wbuf := u.rdmaPool.Get(i)
+
+			// A buffer the worker had to allocate for itself is not in the
+			// pool, so Cleanup will not free it. Track which kind this is:
+			// releasing a pooled buffer here would free it twice.
+			pooled := wbuf != nil
+			defer func() {
+				if wbuf != nil && !pooled {
+					freeRDMABuf(wbuf)
+				}
+			}()
 
 			<-wait
 			for {
@@ -207,26 +221,27 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 						// this only fires if the generator produced something
 						// larger than advertised.
 						if wbuf == nil || wbuf.size < bufSize {
-							if wbuf != nil {
+							if wbuf != nil && !pooled {
 								freeRDMABuf(wbuf)
 							}
+							pooled = false
 							wbuf, err = allocRDMABuf(u.RDMAMode, bufSize)
 						}
 						if err == nil {
 							if stream {
 								opts.RDMABuffer = wbuf.ptr
 								opts.RDMABufferSize = bufSize
-								res, err = client.PutObject(nonTerm, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+								res, err = client.PutObject(ctx, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 							} else if serr := stageToRDMABuf(wbuf, obj.Reader, int(obj.Size)); serr != nil {
 								err = fmt.Errorf("rdma upload prep: %w", serr)
 							} else {
 								opts.RDMABuffer = wbuf.ptr
 								opts.RDMABufferSize = int(obj.Size)
-								res, err = client.PutObject(nonTerm, u.Bucket, obj.Name, nil, obj.Size, opts)
+								res, err = client.PutObject(ctx, u.Bucket, obj.Name, nil, obj.Size, opts)
 							}
 						}
 					} else {
-						res, err = client.PutObject(nonTerm, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+						res, err = client.PutObject(ctx, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 					}
 				} else {
 					op.OpType = http.MethodPost

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -55,6 +55,7 @@ type Put struct {
 	PostObject bool
 	prefixes   map[string]struct{}
 	cl         *http.Client
+	rdmaPool   *rdmaPool
 }
 
 // Prepare will create an empty bucket or delete any content already there.
@@ -64,7 +65,39 @@ func (u *Put) Prepare(ctx context.Context) error {
 			Transport: u.Transport,
 		}
 	}
+	if err := u.prepareRDMAPool(); err != nil {
+		return err
+	}
 	return u.createEmptyBucket(ctx)
+}
+
+// prepareRDMAPool sizes and allocates the pinned buffers before the run.
+//
+// One buffer per worker, sized to hold a whole object when a descriptor can
+// name one, and to a fixed window when it cannot -- past that size the upload
+// streams as multipart and the buffer only selects the RDMA path rather than
+// carrying the object.
+func (u *Put) prepareRDMAPool() error {
+	if u.RDMAMode == RDMAModeOff {
+		return nil
+	}
+	size := int(u.ObjSize)
+	if u.streamsRDMA() {
+		size = rdmaWindowOrDefault(u.RDMAWindow)
+	}
+	pool, err := newRDMAPool(u.RDMAMode, u.Concurrency, size)
+	if err != nil {
+		return err
+	}
+	u.rdmaPool = pool
+	return nil
+}
+
+// streamsRDMA reports whether uploads go out as a multipart stream rather than
+// a single RDMA transfer: either the caller asked for it, or the object is
+// larger than one descriptor can name.
+func (u *Put) streamsRDMA() bool {
+	return u.RDMAWindow > 0 || u.ObjSize > MaxRDMADescriptorSize
 }
 
 // Start will execute the main benchmark.
@@ -113,14 +146,11 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 				}
 			}
 
-			// One source buffer per worker, reused for every op and grown only
-			// when a larger object turns up, so an upload costs no allocation.
-			var wbuf *rdmaBuf
-			defer func() {
-				if wbuf != nil {
-					freeRDMABuf(wbuf)
-				}
-			}()
+			// One pinned buffer per worker, taken from the pool allocated in
+			// Prepare. Allocating here would charge the first operation of
+			// every worker for a page-aligned allocation and the ibv_reg_mr
+			// that pins it -- work unrelated to the transfer being measured.
+			wbuf := u.rdmaPool.Get(i)
 
 			<-wait
 			for {
@@ -154,15 +184,40 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 						// Stage generator output into a CPU or GPU buffer
 						// (per --rdma) so minio-go's RDMA dispatch path can
 						// RDMA-WRITE it directly.
-						if wbuf == nil || wbuf.size < int(obj.Size) {
+						//
+						// With --rdma.window the buffer is a fixed staging
+						// window instead of the whole object: the reader goes
+						// to minio-go, which streams it as an RDMA multipart
+						// upload and pins one part at a time. That is what
+						// carries objects past the 4 GiB an RDMA descriptor
+						// can address, and it keeps a 16 GiB run from asking
+						// for 16 GiB of pinned memory per worker.
+						// A single RDMA transfer cannot name more than a
+						// descriptor's 32-bit size field, so anything larger
+						// has to stream as multipart whether or not it was
+						// asked for. Deciding here rather than letting the
+						// SDK reject it keeps warp from pinning an object's
+						// worth of memory only to fail on every operation.
+						stream := u.streamsRDMA() || obj.Size > MaxRDMADescriptorSize
+						bufSize := int(obj.Size)
+						if stream {
+							bufSize = rdmaWindowOrDefault(u.RDMAWindow)
+						}
+						// The pool is sized from the configured object size, so
+						// this only fires if the generator produced something
+						// larger than advertised.
+						if wbuf == nil || wbuf.size < bufSize {
 							if wbuf != nil {
 								freeRDMABuf(wbuf)
-								wbuf = nil
 							}
-							wbuf, err = allocRDMABuf(u.RDMAMode, int(obj.Size))
+							wbuf, err = allocRDMABuf(u.RDMAMode, bufSize)
 						}
 						if err == nil {
-							if serr := stageToRDMABuf(wbuf, obj.Reader, int(obj.Size)); serr != nil {
+							if stream {
+								opts.RDMABuffer = wbuf.ptr
+								opts.RDMABufferSize = bufSize
+								res, err = client.PutObject(nonTerm, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+							} else if serr := stageToRDMABuf(wbuf, obj.Reader, int(obj.Size)); serr != nil {
 								err = fmt.Errorf("rdma upload prep: %w", serr)
 							} else {
 								opts.RDMABuffer = wbuf.ptr
@@ -209,6 +264,7 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 
 // Cleanup deletes everything uploaded to the bucket.
 func (u *Put) Cleanup(ctx context.Context) {
+	u.rdmaPool.Free()
 	pf := make([]string, 0, len(u.prefixes))
 	for p := range u.prefixes {
 		pf = append(pf, p)

--- a/pkg/bench/rdmabuf.go
+++ b/pkg/bench/rdmabuf.go
@@ -27,6 +27,12 @@ const (
 	RDMAModeGPU = "gpu"
 )
 
+// MaxRDMADescriptorSize is the largest transfer a single RDMA descriptor
+// can name: the x-amz-rdma-token carries the window size in a 32-bit field.
+// A larger object cannot go out as one transfer and has to be streamed as
+// multipart instead.
+const MaxRDMADescriptorSize = 1<<32 - 1
+
 // rdmaBuf is a per-op buffer registered with the NIC for S3-over-RDMA.
 // For CPU mode, ptr is page-aligned host memory from libminiocpp. For GPU
 // mode, ptr is a CUDA device pointer returned by cudaMalloc — see
@@ -106,3 +112,67 @@ func freeRDMABuf(b *rdmaBuf) {
 // could not be loaded on this host.
 var errRDMAGPUUnsupported = errors.New(
 	"rdma=gpu requires an RDMA build of warp and the CUDA runtime on this host")
+
+// rdmaWindowOrDefault sizes the pinned buffer warp hands to a streaming RDMA
+// PUT. The buffer selects the RDMA path rather than carrying the object --
+// libminiocpp allocates and registers the part buffers itself -- so this only
+// needs to be a valid registration, and a small one keeps a run with many
+// workers from pinning more than it needs.
+func rdmaWindowOrDefault(window int64) int {
+	if window > 0 {
+		return int(window)
+	}
+	return 64 << 20
+}
+
+// rdmaPool is a fixed set of pinned buffers, one per worker, allocated and
+// registered before the benchmark starts.
+//
+// Allocating inside the timed loop charges the first operation of every worker
+// for a page-aligned allocation and an ibv_reg_mr that pins the pages -- work
+// that has nothing to do with the transfer being measured, and that a run with
+// many workers pays repeatedly as buffers grow. Paying it up front keeps it out
+// of the measurement entirely.
+type rdmaPool struct {
+	bufs []*rdmaBuf
+}
+
+// newRDMAPool allocates n buffers of size bytes. It cleans up whatever it
+// managed to allocate if one fails, so a partial pool never escapes.
+func newRDMAPool(mode string, n, size int) (*rdmaPool, error) {
+	if mode == RDMAModeOff || n <= 0 || size <= 0 {
+		return nil, nil
+	}
+	p := &rdmaPool{bufs: make([]*rdmaBuf, 0, n)}
+	for i := 0; i < n; i++ {
+		b, err := allocRDMABuf(mode, size)
+		if err != nil {
+			p.Free()
+			return nil, fmt.Errorf("rdma pool: buffer %d of %d (%d bytes each): %w", i+1, n, size, err)
+		}
+		p.bufs = append(p.bufs, b)
+	}
+	return p, nil
+}
+
+// Get returns the buffer belonging to worker i, or nil if there is no pool.
+// Workers never share, so no locking is needed.
+func (p *rdmaPool) Get(i int) *rdmaBuf {
+	if p == nil || len(p.bufs) == 0 {
+		return nil
+	}
+	return p.bufs[i%len(p.bufs)]
+}
+
+// Free releases every buffer in the pool.
+func (p *rdmaPool) Free() {
+	if p == nil {
+		return
+	}
+	for _, b := range p.bufs {
+		if b != nil {
+			freeRDMABuf(b)
+		}
+	}
+	p.bufs = nil
+}

--- a/scripts/build-rdma.sh
+++ b/scripts/build-rdma.sh
@@ -126,7 +126,7 @@ else
 		"${MINIO_CPP_REPO:-https://github.com/minio/minio-cpp}"
 fi
 git -C "${MINIO_CPP_DIR}" fetch --depth 1 origin \
-	"${MINIO_CPP_REF:-f89cc4d25d30057f30a0c3adabe2244c9e222486}"
+	"${MINIO_CPP_REF:-edba72c940b5372afb60817bb5a14124b572135b}"
 git -C "${MINIO_CPP_DIR}" checkout --detach -f FETCH_HEAD
 
 echo ">>> building libminiocpp with RDMA"

--- a/scripts/build-rdma.sh
+++ b/scripts/build-rdma.sh
@@ -107,9 +107,8 @@ fi
 if [ ! -d "${WORK}/vcpkg" ]; then
 	git clone --depth 1 --branch "${VCPKG_REF}" https://github.com/microsoft/vcpkg "${WORK}/vcpkg"
 fi
-# A commit, not a tag: the RDMA transport moved to libs3rdma after v0.5.0 and no
-# release carries it yet. Move this to the tag once one does. init + fetch
-# rather than `clone --branch`, which only accepts a branch or tag.
+# init + fetch rather than `clone --branch`, so this accepts a tag or a commit
+# and a hotfix can be pinned without reworking the script.
 #
 # The fetch and checkout run on every invocation, not just the first. WORK
 # persists between runs to keep them incremental, so a checkout left at an
@@ -126,7 +125,7 @@ else
 		"${MINIO_CPP_REPO:-https://github.com/minio/minio-cpp}"
 fi
 git -C "${MINIO_CPP_DIR}" fetch --depth 1 origin \
-	"${MINIO_CPP_REF:-edba72c940b5372afb60817bb5a14124b572135b}"
+	"${MINIO_CPP_REF:-v0.6.0}"
 git -C "${MINIO_CPP_DIR}" checkout --detach -f FETCH_HEAD
 
 echo ">>> building libminiocpp with RDMA"

--- a/scripts/setup-rdma-release-host.sh
+++ b/scripts/setup-rdma-release-host.sh
@@ -106,7 +106,7 @@ esac
 # minio-go revision in go.mod, and vcpkg's port scripts track the newest CMake.
 # A commit, not a tag: the RDMA transport moved to libs3rdma after v0.5.0 and
 # no release carries it yet. Move this to the tag once one does.
-MINIO_CPP_REF="${MINIO_CPP_REF:-f89cc4d25d30057f30a0c3adabe2244c9e222486}"
+MINIO_CPP_REF="${MINIO_CPP_REF:-edba72c940b5372afb60817bb5a14124b572135b}"
 MINIO_CPP_REPO="${MINIO_CPP_REPO:-https://github.com/minio/minio-cpp}"
 VCPKG_REF="${VCPKG_REF:-2026.07.29}"
 CMAKE_MIN="3.31"

--- a/scripts/setup-rdma-release-host.sh
+++ b/scripts/setup-rdma-release-host.sh
@@ -342,8 +342,8 @@ sync_checkout() {
 		git -C "${dir}" fetch --depth 1 origin "${ref}"
 		git -C "${dir}" reset --hard -q HEAD
 	else
-		# init + fetch rather than `clone --branch`, which only accepts a branch
-		# or tag. Refs here are pinned, and minio-cpp's pin is a commit.
+		# init + fetch rather than `clone --branch`, so a ref here can be a
+		# release tag or a commit. MINIO_CPP_REF selects either.
 		rm -rf "${dir}"
 		git init -q "${dir}"
 		git -C "${dir}" remote add origin "${repo}"

--- a/scripts/setup-rdma-release-host.sh
+++ b/scripts/setup-rdma-release-host.sh
@@ -104,9 +104,8 @@ esac
 # Pinned in lockstep with scripts/build-rdma.sh and .github/workflows/go-rdma.yml:
 # a floating minio-cpp is what leaves a host with headers too old for the
 # minio-go revision in go.mod, and vcpkg's port scripts track the newest CMake.
-# A commit, not a tag: the RDMA transport moved to libs3rdma after v0.5.0 and
-# no release carries it yet. Move this to the tag once one does.
-MINIO_CPP_REF="${MINIO_CPP_REF:-edba72c940b5372afb60817bb5a14124b572135b}"
+# v0.6.0 is the first release carrying the libs3rdma RDMA transport.
+MINIO_CPP_REF="${MINIO_CPP_REF:-v0.6.0}"
 MINIO_CPP_REPO="${MINIO_CPP_REPO:-https://github.com/minio/minio-cpp}"
 VCPKG_REF="${VCPKG_REF:-2026.07.29}"
 CMAKE_MIN="3.31"


### PR DESCRIPTION
Two problems with one cause: RDMA buffers were allocated **inside the timed loop** and sized to the object.

## Pay the cost before the run, not during it

The first operation of every worker paid for a page-aligned allocation and the `ibv_reg_mr` that pins the pages — and paid again whenever a larger object turned up and the buffer had to grow. None of that is the transfer being measured.

A pool of one buffer per worker is now allocated in `Prepare`, so the cost lands before the benchmark starts.

## Objects larger than a descriptor

Sizing the buffer to the object also meant anything past the **4 GiB** an RDMA descriptor can name asked for that much pinned memory and *then* failed on every single operation:

```
warp: <ERROR> upload error: RDMA put: buffer size 5368709120 must be between 0
      and the 4294967295 bytes an RDMA descriptor can describe
```

warp pinned 5 GiB per worker to be told it was too big. Above the threshold the upload now streams as multipart through a fixed 64 MiB buffer, which minio-go turns into RDMA `UploadPart`s ([minio-go#2284](https://github.com/minio/minio-go/pull/2284)), so pinned memory is a window rather than the object.

## The buffer-provided case is unchanged

An object that fits a descriptor still goes out as a **single RDMA transfer from the caller's buffer** — no allocation, no chunking. That remains the fast path and this PR does not disturb it.

`--rdma.window` forces streaming below the threshold, for measuring the streaming path against objects that would otherwise go single-shot.

## Measured

Two-rail mlx5 host, live 4-node cluster:

| | |
|---|---|
| 4 MiB objects, 16 workers | **7177 MiB/s** — unchanged by the pool |
| 5 GiB objects | **upload cleanly**, where they previously failed on every operation |

A server-side trace confirms the small-object path stays single-shot: 13238 `s3.PutObject`, zero `s3.PutObjectPart`.

## Note on chunk size

I tested larger RDMA chunks, expecting them to help. They do not — 16 MiB beats both:

| chunk | throughput |
|---|---|
| 16 MiB | 325.57 MiB/s |
| 256 MiB | 280.87 MiB/s |
| 1 GiB | 211.26 MiB/s |

The fill is serial, so a 1 GiB part spends seconds being read before a byte can move and the pipeline cannot hide it. Chunking stays at libminiocpp's 16 MiB default and this PR adds no knob for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable RDMA transfer windows through a command-line option and environment variable.
  * Enabled multipart RDMA uploads for objects larger than 4 GiB.
  * Improved RDMA transfer efficiency with preallocated, reusable buffers.
  * Added automatic handling for transfers exceeding RDMA descriptor limits.
  * Improved buffer sizing for large-object transfers.
* **Bug Fixes**
  * Invalid RDMA window values now produce a clear configuration error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->