### PR TITLE
fix: do not cancel in-flight PUTs at the end of the run

### DIFF
--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -117,6 +117,7 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 		ctx = c.AutoTerm(ctx, http.MethodPut, u.AutoTermScale, autoTermCheck, autoTermSamples, u.AutoTermDur)
 	}
 	u.prefixes = make(map[string]struct{}, u.Concurrency)
+	nonTerm := context.Background()
 
 	for i := 0; i < u.Concurrency; i++ {
 		src := u.Source()
@@ -231,17 +232,17 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 							if stream {
 								opts.RDMABuffer = wbuf.ptr
 								opts.RDMABufferSize = bufSize
-								res, err = client.PutObject(ctx, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+								res, err = client.PutObject(nonTerm, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 							} else if serr := stageToRDMABuf(wbuf, obj.Reader, int(obj.Size)); serr != nil {
 								err = fmt.Errorf("rdma upload prep: %w", serr)
 							} else {
 								opts.RDMABuffer = wbuf.ptr
 								opts.RDMABufferSize = int(obj.Size)
-								res, err = client.PutObject(ctx, u.Bucket, obj.Name, nil, obj.Size, opts)
+								res, err = client.PutObject(nonTerm, u.Bucket, obj.Name, nil, obj.Size, opts)
 							}
 						}
 					} else {
-						res, err = client.PutObject(ctx, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+						res, err = client.PutObject(nonTerm, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
 					}
 				} else {
 					op.OpType = http.MethodPost


### PR DESCRIPTION
`51b1f72` switched `Put.Start`'s `PutObject` calls from the non-terminating context to the
run-window context, as collateral of the pinned-buffer-pool restructure — the commit body does not
mention it.

The run window is a deadline (`cli/benchmark.go:208`,
`context.WithDeadline(..., tStart.Add(benchDur))`), so at the cut-off every still-in-flight upload
is aborted mid-request and recorded as a benchmark error at `pkg/bench/put.go:257-260`. One
in-flight request per worker, so **the error count came out exactly equal to `--concurrent`**, every
run:

| `--concurrent` | errors reported | throughput |
|---|---|---|
| 2 | 2 | 756.84 MiB/s |
| 4 | 4 | 1513.03 MiB/s |
| 8 | 8 | 3019.54 MiB/s |
| 16 | 16 | 5968.20 MiB/s |

(`warp put`, 8 MiB objects, 15s, plain HTTP against a 4-node AIStor cluster. All errors
`context deadline exceeded`.)

Every other benchmark in `pkg/bench/` declares `nonTerm := context.Background()` for the S3 call and
uses the run context only for the worker's loop-exit `select` — `get.go:205`, `mixed.go:229`,
`multipart_put.go:104`, and 12 more. `put.go` was the sole outlier. This puts it back in line.

`ctrl-c` still aborts: that is implemented by `select { case <-done: return }` at the top of the
worker loop, not by the context handed to `PutObject`. The only thing given up is cancellation of an
already in-flight request, which is what every other benchmark already accepts.

Left on the run context deliberately: `done := ctx.Done()`, `u.rpsLimit(ctx)`,
`c.AutoTerm(ctx, ...)`, and `u.postPolicy(ctx, ...)`. The last only looks like the same bug —
`postPolicy` builds its request with `http.NewRequest` and sends it via `u.cl.Do`, so the context
reaches only `PresignedPostPolicy` and the POST body upload was never cancellable.

### Side effect on reported numbers

Errored operations are dropped before the headline throughput (`aggregate.go:213-215`), but any
error at all sets `opts.Prefiltered` (`aggregate.go:98`), which disables all-threads-active
time-range trimming for that run. So affected runs were also being measured over a wider window
including ramp-up and ramp-down — understating throughput on top of the spurious error count.

### Testing

`go build ./...`, `go vet ./...`, `go test -race ./...` pass; `golangci-lint run -j16` reports 0
issues. Found while testing v1.7.0 RDMA release binaries; the RDMA dispatch path never observed the
Go context and so reported no errors under identical conditions, which is what made the asymmetry
visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upload benchmark operations now complete and report results even if the benchmark context is canceled.
  * Improved consistency for RDMA streaming, staged RDMA, and regular PUT uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->