### PR TITLE
fix(rdma): drop the TTFB column from RDMA PUT reports

### DIFF
--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -260,8 +260,10 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 				// starts, so LastByte would land at the head of the operation and
 				// TTFB would report the whole transfer. Leave it unset and the
 				// column is dropped rather than filled with a number that invites
-				// comparison against the HTTP path.
-				if u.RDMAMode == RDMAModeOff {
+				// comparison against the HTTP path. PostObject is exempt: it never
+				// takes the RDMA branch, and postPolicy streams the body through
+				// obj.Reader, so its LastByte means what it does over plain HTTP.
+				if u.PostObject || u.RDMAMode == RDMAModeOff {
 					op.LastByte = obj.Reader.LastByte()
 				}
 				if err != nil {

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -254,7 +254,16 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) error {
 					}
 				}
 				op.End = time.Now()
-				op.LastByte = obj.Reader.LastByte()
+				// LastByte drives the reported TTFB, as End-LastByte. That only
+				// means anything while the request body streams: the RDMA path
+				// drains the reader into the staging buffer before the transfer
+				// starts, so LastByte would land at the head of the operation and
+				// TTFB would report the whole transfer. Leave it unset and the
+				// column is dropped rather than filled with a number that invites
+				// comparison against the HTTP path.
+				if u.RDMAMode == RDMAModeOff {
+					op.LastByte = obj.Reader.LastByte()
+				}
 				if err != nil {
 					u.Error("upload error: ", err)
 					op.Err = err.Error()


### PR DESCRIPTION
For uploads, TTFB is reported as `End - LastByte`, where `LastByte` is when the generator's reader
hit EOF (`pkg/bench/ops.go:177-186`). That is a meaningful time-to-first-byte only while the request
body is streaming: the reader drains as the body goes out, so what is left over is the server's
response latency.

The RDMA path drains the reader into the staging buffer *before* the transfer is issued
(`stageToRDMABuf`), so `LastByte` lands at the head of the operation and `End - LastByte` covers the
entire data transfer. The two columns then look comparable and are not. Measured on a 4-node AIStor
cluster, `warp put`, `--concurrent=8`, 20s:

| obj size | mode | req avg | reported TTFB |
|---|---|---|---|
| 8 MiB | HTTP | 32.5 ms | 4 ms |
| 8 MiB | `--rdma=cpu` | 14.8 ms | **14 ms** |
| 64 MiB | HTTP | 81.8 ms | 18 ms |
| 64 MiB | `--rdma=cpu` | 103.5 ms | **93 ms** |

RDMA "TTFB" is essentially the whole request, and reading the two side by side produced a wrong
conclusion — that RDMA had a 3-5× latency floor — when the request times say the opposite at that
size (14.8 ms vs 32.5 ms).

Leaving `LastByte` unset drops the column rather than printing a misleading one: `FilterByHasTTFB`
excludes the operation, `TtfbFromBench` returns nil, and the report omits the line. The RDMA GET
path already records no `FirstByte` and so already prints no TTFB — this brings PUT in line with it.

Note this drops the column for **every** RDMA mode, including the `--rdma.window` / large-object
streaming path where the reader really is handed to minio-go and drains as the multipart streams.
That path is the closest of the three to HTTP semantics, but the final part's transfer still
completes after EOF, so `End - LastByte` there is still part transfer rather than server latency.
Gating on the `stream` branch instead of on `RDMAMode` is a one-line change if that is preferred.

### Testing

`go build ./...`, `go vet ./...`, `go test -race ./...` pass; `golangci-lint run -j16` reports 0
issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected upload timing metrics so RDMA staging time is no longer reported as HTTP-style time to first byte.
  * Preserved existing timing behavior for non-RDMA and `PostObject` uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->