### PR TITLE
chore: bump minio-go for the RDMA GET Stat size fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/minio/madmin-go/v4 v4.6.7
 	github.com/minio/mc v0.0.0-20251106162529-77f82e18b540
 	github.com/minio/md5-simd v1.1.2
-	github.com/minio/minio-go/v7 v7.3.1-0.20260815224156-afe8da1cae98
+	github.com/minio/minio-go/v7 v7.3.1-0.20260816235542-f80cde2b89e5
 	github.com/minio/pkg/v3 v3.7.0
 	github.com/minio/websocket v1.6.0
 	github.com/muesli/termenv v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -661,8 +661,8 @@ github.com/minio/mc v0.0.0-20251106162529-77f82e18b540 h1:OAeamQLGQyf7sT/JEocLpA
 github.com/minio/mc v0.0.0-20251106162529-77f82e18b540/go.mod h1:bqx15FhQpl5JfYU3yRM4iz2z2K6DiVSaPbj9P7trZZA=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
-github.com/minio/minio-go/v7 v7.3.1-0.20260815224156-afe8da1cae98 h1:vX7ip+sfhrqCGBpvWP6lyD7OuUT02kuoJbe3YF3Gl2c=
-github.com/minio/minio-go/v7 v7.3.1-0.20260815224156-afe8da1cae98/go.mod h1:KUPWdecEO1LWyUz+sTGXAuf2jZHrPh5fCsRH86QbPfk=
+github.com/minio/minio-go/v7 v7.3.1-0.20260816235542-f80cde2b89e5 h1:RhiGQ8tELV/qw9BTqgfjX4DSMVFhmqBiVYCoKl98cqM=
+github.com/minio/minio-go/v7 v7.3.1-0.20260816235542-f80cde2b89e5/go.mod h1:KUPWdecEO1LWyUz+sTGXAuf2jZHrPh5fCsRH86QbPfk=
 github.com/minio/mux v1.9.0 h1:dWafQFyEfGhJvK6AwLOt83bIG5bxKxKJnKMCi0XAaoA=
 github.com/minio/mux v1.9.0/go.mod h1:1pAare17ZRL5GpmNL+9YmqHoWnLmMZF9C/ioUCfy0BQ=
 github.com/minio/pkg/v3 v3.7.0 h1:0aL3kyWUTwqKXMMq5SQG89UU6u4+Ov2kAdtRS9I8WSQ=


### PR DESCRIPTION
## Description

Bumps `minio-go` to pick up [minio/minio-go#2285](https://github.com/minio/minio-go/pull/2285), which fixes `Stat` reporting `Size: 0` for every RDMA GET.

`GetObject`'s RDMA branch built its `Object` without setting `totalSize`, and `Stat` recomputes `Size` as `totalSize - currOffset`, so it clobbered the real length.

## Motivation

`pkg/bench/get.go` reads the transferred length from `o.Stat()` and compares it against `op.Size`, so on the RDMA path **every** GET was recorded as an error:

```
warp: <ERROR> unexpected download size. want:67108864, got:0
```

Runs against a 4-node cluster showed ~50k errors each while the server-side counters confirmed the bytes had actually been delivered (`rdma_read_ops x 64MiB == rdma_read_bytes`, exactly). The transfers were fine; only the reported size was wrong — which also made warp's error count useless for spotting genuine RDMA failures, since it was saturated with false ones.

Note that throughput accounting credits `op.Size`, not the value returned by `Stat`, so reported bandwidth was unaffected — the numbers were right while every row was flagged as failing.

## How to test

Build with `-tags rdma` and run a GET against a cluster serving S3-over-RDMA:

```
warp get --host <hosts> --bucket <bucket> --list-existing --rdma=cpu --concurrent 16 --duration 30s
```

Before: error count equals (or exceeds) the object count. After: zero errors, throughput unchanged (measured 6434 -> 6372 MiB/s at the same settings, i.e. within noise).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update

## Checklist

- [x] `go mod tidy` clean
- [x] `go build ./...` passes
- [x] Verified the upgraded module contains the fix
- [x] Verified end to end against a live RDMA cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MinIO integration dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->